### PR TITLE
Create Teletext category

### DIFF
--- a/data/categories.csv
+++ b/data/categories.csv
@@ -24,6 +24,7 @@ series,Series
 science,Science
 shop,Shop
 sports,Sports
+teletext,Teletext
 travel,Travel
 weather,Weather
 xxx,XXX


### PR DESCRIPTION
Since the Red Button channels have been included, and there are also channels that report latest releases about TV operators, I guess that instead of categorizing as "news", the "teletext" category should be used. Tagging "teletext" assumes that the channel does not broadcast television programs on video, but in a more interactive interface.

These have been around for years: https://en.wikipedia.org/wiki/List_of_teletext_services