### PR TITLE
add ces language to SK.

### DIFF
--- a/data/countries.csv
+++ b/data/countries.csv
@@ -199,7 +199,7 @@ Seychelles,SC,crs;eng;fra,🇸🇨
 Sierra Leone,SL,eng,🇸🇱
 Singapore,SG,eng;msa;zho;tam,🇸🇬
 Sint Maarten,SX,eng;fra;nld,🇸🇽
-Slovakia,SK,slk,🇸🇰
+Slovakia,SK,slk;ces,🇸🇰
 Slovenia,SI,slv,🇸🇮
 Solomon Islands,SB,eng,🇸🇧
 Somalia,SO,ara;som,🇸🇴


### PR DESCRIPTION
Because CZ also has slk. `Czech Republic,CZ,ces;slk,🇨🇿`