### PR TITLE
Change blocklist.csv: United Media Network AG

### DIFF
--- a/data/blocklist.csv
+++ b/data/blocklist.csv
@@ -85,24 +85,17 @@ beINSportsPremium2.qa,https://github.com/github/dmca/blob/master/2020/09/2020-09
 beINSportsPremium3.qa,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 beINSportsXtra1.qa,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 beINSportsXtra2.qa,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
-BrainzTV.rs,https://github.com/iptv-org/iptv/issues/6486
 BTSportMosaic.uk,https://github.com/iptv-org/iptv/issues/6973
 BTSportMosaic2.uk,https://github.com/iptv-org/iptv/issues/6973
-Cinemania.rs,https://github.com/iptv-org/iptv/issues/6486
 CookingChannel.us,https://github.com/iptv-org/iptv/issues/1831
 CookingChannelCanada.ca,https://github.com/iptv-org/iptv/issues/1831
 DAZN1Germany.de,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 DAZN1GermanyHD.de,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 DAZN2Germany.de,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 DAZN2GermanyHD.de,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
-Diema.bg,https://github.com/iptv-org/iptv/issues/6486
-DiemaFamily.bg,https://github.com/iptv-org/iptv/issues/6486
 DiemaSport.bg,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
-DiemaSport.bg,https://github.com/iptv-org/iptv/issues/6486
 DiemaSport2.bg,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
-DiemaSport2.bg,https://github.com/iptv-org/iptv/issues/6486
 DiemaSport3.bg,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
-DiemaSport3.bg,https://github.com/iptv-org/iptv/issues/6486
 DiscoveryAsia.sg,https://github.com/iptv-org/iptv/issues/1831
 DiscoveryAsiaTaiwan.tw,https://github.com/iptv-org/iptv/issues/1831
 DiscoveryChannelAustralia.au,https://github.com/iptv-org/iptv/issues/1831
@@ -222,7 +215,6 @@ DMAXTaiwan.tw,https://github.com/iptv-org/iptv/issues/1831
 DMAXTurkey.tr,https://github.com/iptv-org/iptv/issues/1831
 DMAXUK.uk,https://github.com/iptv-org/iptv/issues/1831
 DMAXUKPlus1.uk,https://github.com/iptv-org/iptv/issues/1831
-DomaTV.hr,https://github.com/iptv-org/iptv/issues/6486
 Eleven1Belgium.be,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 Eleven2Belgium.be,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 ElevenProLeague1.be,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
@@ -331,7 +323,6 @@ Giallo.it,https://github.com/iptv-org/iptv/issues/1831
 GlobalNews.ca,https://github.com/iptv-org/iptv/pull/6329
 GlobalNewsBC1.ca,https://github.com/iptv-org/iptv/pull/6329
 GolfTV.us,https://github.com/iptv-org/iptv/issues/1831
-Grand.rs,https://github.com/iptv-org/iptv/issues/6486
 HGTVArabia.us,https://github.com/iptv-org/iptv/issues/1831
 HGTVAsia.us,https://github.com/iptv-org/iptv/issues/1831
 HGTVBrazil.br,https://github.com/iptv-org/iptv/issues/1831
@@ -350,7 +341,6 @@ HGTVUK.uk,https://github.com/iptv-org/iptv/issues/1831
 HGTVUKPlus1.uk,https://github.com/iptv-org/iptv/issues/1831
 HGTVWest.us,https://github.com/iptv-org/iptv/issues/1831
 HogarHGTV.us,https://github.com/iptv-org/iptv/issues/1831
-IDJTV.rs,https://github.com/iptv-org/iptv/issues/6486
 InvestigationDiscoveryAfrica.us,https://github.com/iptv-org/iptv/issues/1831
 InvestigationDiscoveryAustralia.au,https://github.com/iptv-org/iptv/issues/1831
 InvestigationDiscoveryBrazil.br,https://github.com/iptv-org/iptv/issues/1831
@@ -375,7 +365,6 @@ ITVNExtra.pl,https://github.com/iptv-org/iptv/issues/1831
 ITVNUSA.us,https://github.com/iptv-org/iptv/issues/1831
 K2.it,https://github.com/iptv-org/iptv/issues/1831
 KDOCDT6.us,https://github.zendesk.com/attachments/token/qCOIlhjNbuhARY64ffpnzv9Ef/?name=2022-01-06-localnow.rtf
-KinoNova.bg,https://github.com/iptv-org/iptv/issues/6486
 KOFYDT6.us,https://github.zendesk.com/attachments/token/qCOIlhjNbuhARY64ffpnzv9Ef/?name=2022-01-06-localnow.rtf
 KUBEDT7.us,https://github.zendesk.com/attachments/token/qCOIlhjNbuhARY64ffpnzv9Ef/?name=2022-01-06-localnow.rtf
 KWHEDT3.us,https://github.com/iptv-org/iptv/issues/9729
@@ -386,7 +375,6 @@ LocalNowManhattan.us,https://github.zendesk.com/attachments/token/qCOIlhjNbuhARY
 LocalNowNewburgh.us,https://github.zendesk.com/attachments/token/qCOIlhjNbuhARY64ffpnzv9Ef/?name=2022-01-06-localnow.rtf
 LocalNowNewYorkCity.us,https://github.zendesk.com/attachments/token/qCOIlhjNbuhARY64ffpnzv9Ef/?name=2022-01-06-localnow.rtf
 LocalNowWhitePlains.us,https://github.zendesk.com/attachments/token/qCOIlhjNbuhARY64ffpnzv9Ef/?name=2022-01-06-localnow.rtf
-Loviribolov.rs,https://github.com/iptv-org/iptv/issues/6486
 MagnoliaNetworkEast.us,https://github.com/iptv-org/iptv/issues/5994
 MagnoliaNetworkWest.us,https://github.com/iptv-org/iptv/issues/5994
 Match.ru,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
@@ -401,14 +389,8 @@ Motortrend.us,https://github.com/iptv-org/iptv/issues/1831
 N1BosniaHerzegovina.ba,https://github.com/iptv-org/iptv/issues/6486
 N1Croatia.hr,https://github.com/iptv-org/iptv/issues/6486
 N1Serbia.rs,https://github.com/iptv-org/iptv/issues/6486
-Nova.bg,https://github.com/iptv-org/iptv/issues/6486
-Novacinema1.gr,https://github.com/iptv-org/iptv/issues/6486
-Novacinema2.gr,https://github.com/iptv-org/iptv/issues/6486
-Novacinema3.gr,https://github.com/iptv-org/iptv/issues/6486
-Novacinema4.gr,https://github.com/iptv-org/iptv/issues/6486
-Novalife.gr,https://github.com/iptv-org/iptv/issues/6486
-NovaSport.bg,https://github.com/iptv-org/iptv/issues/6486
-NovaSport.rs,https://github.com/iptv-org/iptv/issues/6486
+NovaSport.bg,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
+NovaSport.rs,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 NovaSport1.cz,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 NovaSport2.cz,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 NovaSport3.cz,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
@@ -423,8 +405,6 @@ Novasports4.gr,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl
 Novasports4.gr,https://github.com/iptv-org/iptv/issues/6486
 Novasports5.gr,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 Novasports6.gr,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
-NovaTVCroatia.hr,https://github.com/iptv-org/iptv/issues/6486
-NovaTVSerbia.rs,https://github.com/iptv-org/iptv/issues/6486
 Nove.it,https://github.com/iptv-org/iptv/issues/1831
 One.il,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 OrangeSport1.ro,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
@@ -435,7 +415,6 @@ OWNCanada.ca,https://github.com/iptv-org/iptv/issues/1831
 OWNEast.us,https://github.com/iptv-org/iptv/issues/1831
 OWNWest.us,https://github.com/iptv-org/iptv/issues/1831
 Pattrn.us,https://github.com/iptv-org/iptv/issues/9729
-Pikaboo.rs,https://github.com/iptv-org/iptv/issues/6486
 PPTV.th,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 PrimaSport1.ro,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 PrimaSport2.ro,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
@@ -677,7 +656,6 @@ TVNorge.no,https://github.com/iptv-org/iptv/issues/1831
 TVNStyle.pl,https://github.com/iptv-org/iptv/issues/1831
 TVNTurbo.pl,https://github.com/iptv-org/iptv/issues/1831
 TVVarzish.tj,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
-Vavoom.rs,https://github.com/iptv-org/iptv/issues/6486
 VOX.no,https://github.com/iptv-org/iptv/issues/1831
 VSport1Finland.fi,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 VSport1Norway.no,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md


### PR DESCRIPTION
Address concern regarding United Media Network AG.
In iptv-org/iptv#6486,
The DMCA only states that N1 to be removed. It doesn't explicitly mentions to remove all channels from United Media Network AG.
I've kept the sports related channels in.