### PR TITLE
Change ts-node to tsx in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
     "act:check": "act pull_request -W .github/workflows/check.yml",
     "act:update": "act workflow_dispatch -W .github/workflows/update.yml",
     "act:deploy": "act push -W .github/workflows/deploy.yml",
-    "db:validate": "ts-node scripts/db/validate.ts",
-    "db:export": "ts-node scripts/db/export.ts",
-    "db:update": "ts-node scripts/db/update.ts",
+    "db:validate": "tsx scripts/db/validate.ts",
+    "db:export": "tsx scripts/db/export.ts",
+    "db:update": "tsx scripts/db/update.ts",
     "lint": "npx eslint \"{scripts,tests}/**/*.{ts,js}\"",
     "test": "jest --runInBand"
   },
   "engines": {
-    "node": ">=18.0.0 <18.19.0"
+    "node": "^18.*"
   },
   "pre-commit": [
     "db:validate"
@@ -43,7 +43,7 @@
     "jest": "^29.7.0",
     "joi": "^17.6.0",
     "ts-jest": "^29.1.1",
-    "ts-node": "^10.9.1"
+    "tsx": "^4.10.5"
   },
   "devDependencies": {
     "pre-commit": "^1.2.2"


### PR DESCRIPTION
Nodejs v18.19.0 breaks ts-node.

See:

https://nodejs.org/en/blog/release/v18.19.0
https://github.com/TypeStrong/ts-node/issues/2094