### PR TITLE
Update blocklist.csv

### DIFF
--- a/data/blocklist.csv
+++ b/data/blocklist.csv
@@ -960,9 +960,7 @@ SuperSportKosova2.xk,https://github.com/github/dmca/blob/master/2020/09/2020-09-
 SuperSportKosova3.xk,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 TAPSports.ph,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 TBSEast.us,https://github.com/iptv-org/iptv/issues/16839
-TBSTV.kr,https://github.com/iptv-org/iptv/issues/16839
 TBSWest.us,https://github.com/iptv-org/iptv/issues/16839
-TCM10HD.br,https://github.com/iptv-org/iptv/issues/16839
 TCMEast.us,https://github.com/iptv-org/iptv/issues/16839
 TCMEast.us,https://github.com/iptv-org/iptv/issues/16839
 TCMWest.us,https://github.com/iptv-org/iptv/issues/16839
@@ -1058,8 +1056,6 @@ TTV.pl,https://github.com/iptv-org/iptv/issues/1831
 TUSHY.us,https://github.com/iptv-org/iptv/issues/15723
 TUSHYRAW.us,https://github.com/iptv-org/iptv/issues/15723
 TV3Sport.dk,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
-TVN.cl,https://github.com/iptv-org/iptv/issues/16839
-TVN.ee,https://github.com/iptv-org/iptv/issues/16839
 TVN.pl,https://github.com/iptv-org/iptv/issues/1831
 TVN24.pl,https://github.com/iptv-org/iptv/issues/1831
 TVN24BiS.pl,https://github.com/iptv-org/iptv/issues/1831


### PR DESCRIPTION
Fix erroneous channels not owned by Warner Bros./Discovery.

Partial revert commit #12348.

Reference:
#12533