### PR TITLE
Update blocklist.csv

### DIFF
--- a/data/blocklist.csv
+++ b/data/blocklist.csv
@@ -1065,6 +1065,8 @@ TVNorge.no,https://github.com/iptv-org/iptv/issues/1831
 TVNStyle.pl,https://github.com/iptv-org/iptv/issues/1831
 TVNTurbo.pl,https://github.com/iptv-org/iptv/issues/1831
 TVVarzish.tj,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
+TVP1.pl,https://github.com/iptv-org/iptv/issues/6973
+TVPSport.pl,https://github.com/iptv-org/iptv/issues/6973
 VanillaSkyChannel.jp,https://github.com/iptv-org/iptv/issues/15723
 Venus.ar,https://github.com/iptv-org/iptv/issues/15723
 VENUS.jp,https://github.com/iptv-org/iptv/issues/15723


### PR DESCRIPTION
TVP 1 and TVP Sport are reported to be streaming previously claimed DMCA content. We'll play safe and ban them from the repositories.