### PR TITLE
Update subdivisions.csv

### DIFF
--- a/data/subdivisions.csv
+++ b/data/subdivisions.csv
@@ -3198,7 +3198,6 @@ UK,Wales,GB-WLS
 UM,Palmyra Atoll,UM-95
 US,Alabama,US-AL
 US,Alaska,US-AK
-US,American Samoa,US-AS
 US,Arizona,US-AZ
 US,Arkansas,US-AR
 US,California,US-CA
@@ -3208,7 +3207,6 @@ US,Delaware,US-DE
 US,District of Columbia,US-DC
 US,Florida,US-FL
 US,Georgia,US-GA
-US,Guam,US-GU
 US,Hawaii,US-HI
 US,Idaho,US-ID
 US,Illinois,US-IL
@@ -3233,18 +3231,15 @@ US,New Mexico,US-NM
 US,New York,US-NY
 US,North Carolina,US-NC
 US,North Dakota,US-ND
-US,Northern Mariana Islands,US-MP
 US,Ohio,US-OH
 US,Oklahoma,US-OK
 US,Oregon,US-OR
 US,Pennsylvania,US-PA
-US,Puerto Rico,US-PR
 US,Rhode Island,US-RI
 US,South Carolina,US-SC
 US,South Dakota,US-SD
 US,Tennessee,US-TN
 US,Texas,US-TX
-US,U.S. Virgin Islands,US-VI
 US,United States Minor Outlying Islands,US-UM
 US,Utah,US-UT
 US,Vermont,US-VT


### PR DESCRIPTION
Deleted codes of US dependent territories to avoid confusion with codes of the same countries in [countries.csv](https://github.com/iptv-org/database/blob/master/data/countries.csv).

Source: https://en.wikipedia.org/wiki/Dependent_territory#United_States