### PR TITLE
Change ID and country of certain GEM TVs.

### DIFF
--- a/data/feeds.csv
+++ b/data/feeds.csv
@@ -9908,10 +9908,17 @@ GEMJunior.ca,SD,SD,TRUE,c/CA;c/IR,America/Toronto,fas,480i
 GEMKids.ca,SD,SD,TRUE,c/CA;c/IR,America/Toronto,fas,480i
 GEMLatino.ca,SD,SD,TRUE,c/CA;c/IR,America/Toronto,fas,480i
 GEMLife.ca,SD,SD,TRUE,c/CA;c/IR,America/Toronto,fas,480i
+GEMMifa.ca,SD,SD,TRUE,c/IR,Asia/Tehran,fas,576i
+GEMMifaPlus.ca,SD,SD,TRUE,c/IR,Asia/Tehran,fas,576i
 GEMNature.ca,SD,SD,TRUE,c/CA;c/IR,America/Toronto,fas,480i
+GEMOnyx.ca,SD,SD,TRUE,c/IR,Asia/Tehran,fas,576i
 GEMPlus.ca,SD,SD,TRUE,c/CA;c/IR,America/Toronto,fas,480i
 Gemporia.uk,SD,SD,TRUE,c/UK,Europe/London,eng,576i
 GEMProperty.ca,SD,SD,TRUE,c/CA;c/IR,America/Toronto,fas,480i
+GEMRiver.ca,SD,SD,TRUE,c/IR,Asia/Tehran,fas,576i
+GEMRiverPlus.ca,SD,SD,TRUE,c/IR,Asia/Tehran,fas,576i
+GEMRubix.ca,SD,SD,TRUE,c/IR,Asia/Tehran,fas,576i
+GEMRubixPlus.ca,SD,SD,TRUE,c/IR,Asia/Tehran,fas,576i
 GEMSeries.ca,SD,SD,TRUE,c/CA;c/IR,America/Toronto,fas,480i
 GEMSeriesPlus.ca,SD,SD,TRUE,c/CA;c/IR,America/Toronto,fas,480i
 GemShoppingNetwork.us,SD,SD,TRUE,c/US,America/Chicago,eng,480i
@@ -19735,8 +19742,6 @@ MIEM.uy,SD,SD,TRUE,c/UY,America/Montevideo,spa,576i
 MienTayTV.vn,SD,SD,TRUE,c/VN,Asia/Ho_Chi_Minh,vie,576i
 MierschTV.lu,SD,SD,TRUE,c/LU,Europe/Luxembourg,ltz,576i
 MiExtranaObsesion.us,Spain,Spain,TRUE,c/ES,Europe/Madrid,spa,576i
-Mifa.ir,SD,SD,TRUE,c/IR,Asia/Tehran,fas,576i
-MifaPlus.ir,SD,SD,TRUE,c/IR,Asia/Tehran,fas,576i
 MiGenteTV.co,SD,SD,TRUE,c/CO,America/Bogota,spa,480i
 MightyTV.gh,SD,SD,TRUE,c/GH,Africa/Accra,eng,576i
 MihanTV.ir,SD,SD,TRUE,c/IR,Asia/Tehran,fas,576i
@@ -22439,7 +22444,6 @@ ONTVNigeria.ng,SD,SD,TRUE,c/NG,Africa/Lagos,eng,576i
 ONTVPublicAccess.us,SD,SD,TRUE,s/US-MI,America/New_York,eng,480i
 OnuaTV.gh,SD,SD,TRUE,c/GH,Africa/Accra,eng,576i
 ONVieDrama.vn,SD,SD,TRUE,c/VN,Asia/Ho_Chi_Minh,vie,576i
-Onyx.ir,SD,SD,TRUE,c/IR,Asia/Tehran,fas,576i
 OnzaTV.ve,SD,SD,TRUE,c/VE,America/Santiago,spa,480i
 OOGTV.nl,SD,SD,TRUE,c/NL,Europe/Amsterdam,nld,576i
 OPA.cr,SD,SD,TRUE,c/CR,America/La_Paz,spa,480i
@@ -25262,9 +25266,7 @@ RitmuTV.kw,SD,SD,TRUE,c/KW,Asia/Kuwait,ara,576i
 RITNoticias.br,SD,SD,TRUE,c/BR,America/Sao_Paulo,por,480i
 RitsaTV.ru,SD,SD,TRUE,c/RU,Europe/Moscow,rus,576i
 RITTV.br,SD,SD,TRUE,c/BR,America/Sao_Paulo,por,480i
-River.ir,SD,SD,TRUE,c/IR,Asia/Tehran,fas,576i
 RiverheadChannel22.us,SD,SD,TRUE,s/US-NY,America/New_York,eng,480i
-RiverPlus.ir,SD,SD,TRUE,c/IR,Asia/Tehran,fas,576i
 RiversideBrookfieldHighSchoolTV.us,SD,SD,TRUE,s/US-IL,America/Los_Angeles,eng,480i
 RiversideTV.us,SD,SD,TRUE,s/US-CA,America/Los_Angeles,eng,480i
 RiverTV.et,SD,SD,TRUE,c/ET,Africa/Addis_Ababa,amh,576i
@@ -25808,8 +25810,6 @@ RTVZivinice.ba,SD,SD,TRUE,c/BA,Europe/Sarajevo,bos,576i
 RTVZulthe.nl,SD,SD,TRUE,c/NL,Europe/Amsterdam,nld,576i
 RuaiTV.id,SD,SD,TRUE,s/ID-KB,Asia/Pontianak,ind,576i
 RuangTrampil.id,SD,SD,TRUE,c/ID,Asia/Jakarta,ind,576i
-Rubix.ir,SD,SD,TRUE,c/IR,Asia/Tehran,fas,576i
-RubixPlus.ir,SD,SD,TRUE,c/IR,Asia/Tehran,fas,576i
 Rudana.ua,SD,SD,TRUE,c/UA,Europe/Kyiv,ukr,576i
 RudawTV.iq,SD,SD,TRUE,c/IQ,Asia/Baghdad,kur,576i
 RugbyPassTV.uk,SD,SD,TRUE,c/UK,Europe/London,eng,576i


### PR DESCRIPTION
Hello,
This PR updates the IDs of the following networks.

| Current ID         | New ID              |
|--------------------|--------------------|
| Mifa.ca           | GEMMifa.ca         |
| MifaPlus.ir       | GEMMifaPlus.ca     |
| Onyx.ca           | GEMOnyx.ca         |
| River.ca          | GEMRiver.ca        |
| RiverPlus.ir      | GEMRiverPlus.ca    |
| Rubix.ca          | GEMRubix.ca        |
| RubixPlus.ir      | GEMRubixPlus.ca    |