### PR TITLE
Patch 2025.05.2

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,8 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
       - uses: actions/setup-node@v3
         if: ${{ !env.ACT }}
         with:
@@ -18,9 +16,9 @@ jobs:
       - name: changed files
         id: files
         run: |
-          FILES=data/*.csv
+          git fetch origin master:master
           ANY_CHANGED=false
-          ALL_CHANGED_FILES=$(git diff --name-only "${FILES}" | tr '\n' ' ')
+          ALL_CHANGED_FILES=$(git diff --name-only master -- data/ | tr '\n' ' ')
           if [ -n "${ALL_CHANGED_FILES}" ]; then
             ANY_CHANGED=true
           fi

--- a/data/blocklist.csv
+++ b/data/blocklist.csv
@@ -1,5 +1,5 @@
 channel,reason,ref
-21Sextury.us,nsfw,https://github.com/iptv-org/iptv/issues/15723
+21Sextury.fr,nsfw,https://github.com/iptv-org/iptv/issues/15723
 40Plus.uk,nsfw,https://github.com/iptv-org/iptv/issues/15723
 5StarMax.us,dmca,https://github.com/iptv-org/iptv/issues/16839
 6eren.dk,dmca,https://github.com/iptv-org/iptv/issues/16839

--- a/data/blocklist.csv
+++ b/data/blocklist.csv
@@ -1,5 +1,5 @@
 channel,reason,ref
-21Sextury.fr,nsfw,https://github.com/iptv-org/iptv/issues/15723
+21Sextury.us,nsfw,https://github.com/iptv-org/iptv/issues/15723
 40Plus.uk,nsfw,https://github.com/iptv-org/iptv/issues/15723
 5StarMax.us,dmca,https://github.com/iptv-org/iptv/issues/16839
 6eren.dk,dmca,https://github.com/iptv-org/iptv/issues/16839

--- a/scripts/core/issueParser.ts
+++ b/scripts/core/issueParser.ts
@@ -31,6 +31,8 @@ const FIELDS = new Dictionary({
 
 export class IssueParser {
   parse(issue: { number: number; body: string; labels: { name: string }[] }): Issue {
+    if (!issue.body) throw new Error('Issue body is missing')
+
     const fields = issue.body.split('###')
 
     const data = new Dictionary()


### PR DESCRIPTION
Fixes `check` workflow.

The`validate` job should run if at least one file in the `data/` folder has been changed. At the moment this does not happen: https://github.com/iptv-org/database/actions/runs/15106876584/job/42492468608?pr=18158