### PR TITLE
Patch 2025.05.3

### DIFF
--- a/scripts/commands/db/update.ts
+++ b/scripts/commands/db/update.ts
@@ -407,4 +407,8 @@ function onChannelRemoval(channelId: string, data: DataLoaderData) {
   })
 
   data.feeds.remove((feed: Feed) => feed.channelId === channelId)
+
+  data.blocklistRecords.remove(
+    (blocklistRecord: BlocklistRecord) => blocklistRecord.channelId === channelId
+  )
 }

--- a/tests/__data__/input/db/update/data/blocklist.csv
+++ b/tests/__data__/input/db/update/data/blocklist.csv
@@ -1,3 +1,4 @@
 channel,reason,ref
 AnimalPlanetAfrica.za,dmca,https://github.com/iptv-org/iptv/issues/1831
 BeijingSatelliteTV.cn,dmca,https://github.com/iptv-org/iptv/issues/1831
+002RadioTV.do,dmca,https://github.com/iptv-org/iptv/issues/1831


### PR DESCRIPTION
When deleting a channel via [form](https://github.com/iptv-org/database/issues/new?template=3_channels_remove.yml), the blocklist entry will now be deleted as well.

Fixes: https://github.com/iptv-org/database/actions/runs/15235061169/job/42847771459

Test results:

```sh
npm test          

> test
> jest --runInBand

 PASS  tests/commands/db/validate.test.ts (11.021 s)
 PASS  tests/commands/db/update.test.ts
 PASS  tests/commands/db/export.test.ts

Test Suites: 3 passed, 3 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        14.187 s, estimated 21 s
Ran all test suites.
```