### PR TITLE
Update countries.csv Replace Turkey to Türkiye

### DIFF
--- a/data/countries.csv
+++ b/data/countries.csv
@@ -227,7 +227,7 @@ Tokelau,TK,eng;smo;tkl,🇹🇰
 Tonga,TO,eng;ton,🇹🇴
 Trinidad and Tobago,TT,eng,🇹🇹
 Tunisia,TN,ara,🇹🇳
-Türkiye,TR,tur,🇹🇷
+Turkiye,TR,tur,🇹🇷
 Turkmenistan,TM,rus;tuk,🇹🇲
 Turks and Caicos Islands,TC,eng,🇹🇨
 Tuvalu,TV,eng;tvl,🇹🇻

--- a/data/countries.csv
+++ b/data/countries.csv
@@ -227,7 +227,7 @@ Tokelau,TK,eng;smo;tkl,🇹🇰
 Tonga,TO,eng;ton,🇹🇴
 Trinidad and Tobago,TT,eng,🇹🇹
 Tunisia,TN,ara,🇹🇳
-Turkey,TR,tur,🇹🇷
+Türkiye,TR,tur,🇹🇷
 Turkmenistan,TM,rus;tuk,🇹🇲
 Turks and Caicos Islands,TC,eng,🇹🇨
 Tuvalu,TV,eng;tvl,🇹🇻


### PR DESCRIPTION
Turkey officially changes name at UN to Türkiye https://turkiye.un.org/en/184798-turkeys-name-changed-t%C3%BCrkiye

See for more details: https://www.theguardian.com/world/2022/jun/03/turkey-changes-name-to-turkiye-as-other-name-is-for-the-birds