### PR TITLE
Samsung movie sphere channel

### DIFF
--- a/data/feeds.csv
+++ b/data/feeds.csv
@@ -27559,7 +27559,6 @@ SouthernKantoRegionalHorseRacingChannel.jp,SD,SD,TRUE,c/JP,Asia/Tokyo,jpn,480i
 SouthernShoppingChannel.cn,SD,SD,TRUE,c/CN,Asia/Shanghai,zho,576i
 SouthHavenGovernmentAccess.us,SD,SD,TRUE,s/US-MI,America/New_York,eng,480i
 SouthPark.us,France,France,TRUE,c/FR,Europe/Paris,fra,576i
-SouthPark.us,Canada,Canada,TRUE,c/CA,America/Toronto,eng,576i
 SouthwickChannel15.us,SD,SD,TRUE,s/US-MA,America/New_York,eng,480i
 SoutMasr.eg,SD,SD,TRUE,c/EG,Africa/Cairo,ara,576i
 SOUTV.br,SD,SD,TRUE,s/BR-RS,America/Sao_Paulo,por,480i

--- a/data/feeds.csv
+++ b/data/feeds.csv
@@ -26014,6 +26014,7 @@ SamoborTV.hr,SD,SD,TRUE,c/HR,Europe/Zagreb,hrv,576i
 SAMPublicChannel.us,SD,SD,TRUE,s/US-MA,America/New_York,eng,480i
 Samrujlok.th,SD,SD,TRUE,c/TH,Asia/Bangkok,tha;eng,576i
 SamsungWildlife.us,SD,SD,TRUE,c/US,America/New_York,eng,480i
+SamsungMovieSphere.us,SD,SD,TRUE,c/US,America/New_York,eng,720p
 SAMTV.lr,SD,SD,TRUE,c/LR,Africa/Monrovia,eng,576i
 SamuderaTV.id,SD,SD,TRUE,c/ID,Asia/Jakarta,ind,576i
 SamuelGoldwynChannel.us,SD,SD,TRUE,c/US,America/New_York,eng,480i
@@ -27558,6 +27559,7 @@ SouthernKantoRegionalHorseRacingChannel.jp,SD,SD,TRUE,c/JP,Asia/Tokyo,jpn,480i
 SouthernShoppingChannel.cn,SD,SD,TRUE,c/CN,Asia/Shanghai,zho,576i
 SouthHavenGovernmentAccess.us,SD,SD,TRUE,s/US-MI,America/New_York,eng,480i
 SouthPark.us,France,France,TRUE,c/FR,Europe/Paris,fra,576i
+SouthPark.us,Canada,Canada,TRUE,c/CA,America/Toronto,eng,576i
 SouthwickChannel15.us,SD,SD,TRUE,s/US-MA,America/New_York,eng,480i
 SoutMasr.eg,SD,SD,TRUE,c/EG,Africa/Cairo,ara,576i
 SOUTV.br,SD,SD,TRUE,s/BR-RS,America/Sao_Paulo,por,480i


### PR DESCRIPTION
The samsung tv channel has different content , and a different EPG, than the normal movie sphere channel.

See: PRs: https://github.com/iptv-org/epg/pull/2808 and https://github.com/iptv-org/iptv/pull/24887