### PR TITLE
Add CRLF check on actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,7 +33,7 @@ jobs:
           directory: ./data
           line_ending_type: 'CRLF'
           include_pattern: '*.csv'
-          pattern_type: 'glob'
+          pattern_type: 'shell_glob'
       - name: validate
         if: steps.files.outputs.any_changed == 'true'
         run: npm run db:validate

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,7 +31,6 @@ jobs:
         continue-on-error: false
         with:
           directory: ./data
-          line_ending_type: 'CRLF'
       - name: validate
         if: steps.files.outputs.any_changed == 'true'
         run: npm run db:validate

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,11 +26,14 @@ jobs:
       - name: install dependencies
         if: steps.files.outputs.any_changed == 'true'
         run: npm install
-      - name: Use action to check for CRLF endings
+      - name: check if files are crlf
         uses: kforeverisback/check-crlf-extended@v2
         continue-on-error: false
         with:
           directory: ./data
+          line_ending_type: 'CRLF'
+          include_pattern: '*.csv'
+          pattern_type: 'glob'
       - name: validate
         if: steps.files.outputs.any_changed == 'true'
         run: npm run db:validate

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,10 +26,12 @@ jobs:
       - name: install dependencies
         if: steps.files.outputs.any_changed == 'true'
         run: npm install
-      - name: check if files are crlf
-        uses: erclu/check-crlf@v1
+      - name: Use action to check for CRLF endings
+        uses: kforeverisback/check-crlf-extended@v2
+        continue-on-error: false
         with:
-          path: ./data
+          directory: ./data
+          line_ending_type: 'CRLF'
       - name: validate
         if: steps.files.outputs.any_changed == 'true'
         run: npm run db:validate

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,6 +26,10 @@ jobs:
       - name: install dependencies
         if: steps.files.outputs.any_changed == 'true'
         run: npm install
+      - name: check if files are crlf
+        uses: erclu/check-crlf@v1
+        with:
+          path: ./data
       - name: validate
         if: steps.files.outputs.any_changed == 'true'
         run: npm run db:validate

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -36,7 +36,7 @@ jobs:
           directory: ./data
           line_ending_type: 'CRLF'
           include_pattern: '*.csv'
-          pattern_type: 'glob'
+          pattern_type: 'shell_glob'
       - name: setup git
         run: |
           git config user.name "iptv-bot[bot]"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,6 +29,10 @@ jobs:
         run: npm run db:update --silent >> $GITHUB_OUTPUT
       - name: validate changes
         run: npm run db:validate
+      - name: check if files are crlf
+        uses: erclu/check-crlf@v1
+        with:
+          path: ./data
       - name: setup git
         run: |
           git config user.name "iptv-bot[bot]"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,10 +29,12 @@ jobs:
         run: npm run db:update --silent >> $GITHUB_OUTPUT
       - name: validate changes
         run: npm run db:validate
-      - name: check if files are crlf
-        uses: erclu/check-crlf@v1
+      - name: Use action to check for CRLF endings
+        uses: kforeverisback/check-crlf-extended@v2
+        continue-on-error: false
         with:
-          path: ./data
+          directory: ./data
+          line_ending_type: 'CRLF'
       - name: setup git
         run: |
           git config user.name "iptv-bot[bot]"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -34,7 +34,6 @@ jobs:
         continue-on-error: false
         with:
           directory: ./data
-          line_ending_type: 'CRLF'
       - name: setup git
         run: |
           git config user.name "iptv-bot[bot]"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,11 +29,14 @@ jobs:
         run: npm run db:update --silent >> $GITHUB_OUTPUT
       - name: validate changes
         run: npm run db:validate
-      - name: Use action to check for CRLF endings
+      - name: check if files are crlf
         uses: kforeverisback/check-crlf-extended@v2
         continue-on-error: false
         with:
           directory: ./data
+          line_ending_type: 'CRLF'
+          include_pattern: '*.csv'
+          pattern_type: 'glob'
       - name: setup git
         run: |
           git config user.name "iptv-bot[bot]"


### PR DESCRIPTION
This adds [check-crlf-extended](https://www.github.com/kforeverisback/check-crlf-extended/tree/v2/) to the repository, to prevent the files that aren't CRLF to refuse merging.