### PR TITLE
Update 09_logos_remove.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/09_logos_remove.yml
+++ b/.github/ISSUE_TEMPLATE/09_logos_remove.yml
@@ -35,6 +35,7 @@ body:
       options:
         - 'Not loading'
         - 'Geo-blocked'
+        - 'Wrong channel ID'
         - 'Other'
     validations:
       required: true


### PR DESCRIPTION
Adds a new reason for removing the logo: “Wrong channel ID”.