### PR TITLE
RTP Notícias logo fix

### DIFF
--- a/data/logos.csv
+++ b/data/logos.csv
@@ -27000,7 +27000,7 @@ RTPMadeira.pt,,,500,59,PNG,https://i.imgur.com/nJNWTqA.png
 RTPMadeira.pt,,picons,220,132,PNG,https://i.postimg.cc/mgqjTNBr/rtpmadeira.png
 RTPMemoria.pt,,,510,61,PNG,https://i.imgur.com/jCpfdiJ.png
 RTPMemoria.pt,,picons,220,132,PNG,https://i.postimg.cc/hGdrvzt1/rtpmemoria.png
-RTPNoticias.pt,,,185,21,PNG,https://imgur.com/a/rtp-not-cias-wn7ydOr
+RTPNoticias.pt,,,185,21,PNG,https://i.imgur.com/Bm2XEHH.png
 RTPTelevision.co,,,400,400,PNG,https://i.imgur.com/13ARpTZ.png
 RTQQueretaro.mx,,,438,226,PNG,https://i.imgur.com/RRckCvf.png
 RTRBelarus.by,,,799,184,JPEG,https://upload.wikimedia.org/wikipedia/commons/thumb/a/a8/Rtr-belarus.jpg/800px-Rtr-belarus.jpg


### PR DESCRIPTION
Some days ago, I made a PR to add the new renewed portuguese channel to the database, but I put the wrong logo link.
This PR will fix it, I have just changed the link from:
`https://imgur.com/a/rtp-not-cias-wn7ydOr`, which will redirect to the real website
to:
`https://i.imgur.com/Bm2XEHH.png`, which shows the real PNG logo.