### PR TITLE
SBS9.nl, ViaplayTV.nl and Veronica.nl

### DIFF
--- a/data/channels.csv
+++ b/data/channels.csv
@@ -24808,8 +24808,8 @@ SBNTVInternational.us,SBN TV International,,,,US,religious,FALSE,,,,https://www.
 SBS.au,SBS,,,,AU,,FALSE,,,,https://www.sbs.com.au/guide/channel/SBS
 SBS.kr,SBS,Seoul Broadcasting System,,,KR,,FALSE,1991-12-09,,,https://www.sbs.co.kr/
 SBS.us,SBS,Shinniigaa Broadcasting Service,,,US,news,FALSE,,,,
-SBS6.nl,SBS 6,,,,NL,,FALSE,,,,https://www.sbs6.nl/
-SBS9.nl,SBS 9,,,,NL,,FALSE,,2024-04-05,ViaplayTv.nl,https://www.sbs9.nl/
+SBS6.nl,SBS 6,,,Talpa Network,NL,,FALSE,,,,https://www.sbs6.nl/
+SBS9.nl,SBS 9,,,Talpa Network,NL,,FALSE,,,,https://www.sbs9.nl/
 SBSBiz.kr,SBS Biz,,,SBS Media Holdings,KR,business,FALSE,2021-01-01,,,https://biz.sbs.co.kr/
 SBSFL.kr,SBS F!L,SBS 필,,,KR,entertainment,FALSE,2019-10-01,,,https://fil.sbs.co.kr/
 SBSFood.au,SBS Food,,SBS Television,Special Broadcasting Service,AU,cooking,FALSE,,,,https://www.sbs.com.au/guide/channel/SBSFood
@@ -31037,8 +31037,7 @@ VeritasTV.cm,Veritas TV,,,,CM,,FALSE,,,,
 VeriteTV.uk,Verite TV,Vérité TV,,,UK,religious,FALSE,,,,https://xn--vrittv-bvad.com/
 VermontCommunityTelevision.us,Vermont Community Television,VCTV,,,US,general,FALSE,,,,https://www.catamountaccess.com/statewidechannel1070
 VernierVisions.ch,Vernier Visions,,,,CH,,FALSE,,,,
-Veronica.nl,Veronica,,,Talpa Network,NL,,FALSE,,,,http://www.veronicatv.nl/
-VeronicaDisneyXD.nl,Veronica/Disney XD,,,,NL,,FALSE,,,,https://www.tvgids.nl/gids/veronicadisneyxd
+Veronica.nl,Veronica / Disney Jr.,,,Talpa Network,NL,,FALSE,,,,http://www.veronicatv.nl/
 VertsPaturagesTV.cd,Verts Paturages TV,Verts Pâturages TV,,,CD,general,FALSE,,,,
 VeryLocal.us,Very Local,,,Hearst Television,US,news,FALSE,2021-09-20,,,https://www.verylocal.com/
 VeryTV.th,Very TV,,,,TH,,FALSE,,,,
@@ -31108,7 +31107,7 @@ ViaOccitanieMontpellier.fr,ViaOccitanie Montpellier,ViàOccitanie Montpellier,Vi
 ViaOccitaniePaysCatalan.fr,ViaOccitanie Pays Catalan,ViàOccitanie Pays Catalan,ViàOccitanie,Groupe La Dépêche du Midi,FR,general,FALSE,2015-07-20,,,https://viaoccitanie.tv/
 ViaOccitaniePaysGardois.fr,ViaOccitanie Pays Gardois,ViàOccitanie Pays Gardois,ViàOccitanie,Groupe La Dépêche du Midi,FR,general,FALSE,2011-02-07,,,https://viaoccitanie.tv/
 ViaOccitanieToulouse.fr,ViaOccitanie Toulouse,ViàOccitanie Toulouse,ViàOccitanie,Groupe La Dépêche du Midi,FR,general,FALSE,2017-09-28,,,https://viaoccitanie.tv/
-ViaplayTv.nl,Viaplay Tv,,,,NL,,FALSE,,,,https://viaplay.com/nl-nl/
+ViaplayTV.nl,Viaplay TV,,,,NL,,FALSE,,,,https://viaplay.com/nl-nl/
 ViaplayXtra.uk,Viaplay Xtra,FreeSports,,Viaplay Group AB,UK,sports,FALSE,2017-08-31,,,https://www.premiersports.com/
 Viasat2.hu,Viasat2,Sony Max Hungary;AXN White Hungary;AXN Crime Hungary,,Antenna Group,HU,,FALSE,2006-01-01,,,https://www.viasat2.hu/
 Viasat3.hu,Viasat 3,,,AXN Europe Limited,HU,,FALSE,2000-10-23,,,https://www.viasat3.hu/


### PR DESCRIPTION
There was some confusion on "SBS9" turning into "Viaplay TV", however they ended up to be 2 separate channels. "Veronica" has a shared timeslot on the same channel with "Disney Jr.", which used to be "Disney XD".