### PR TITLE
Add HD feeds for `.nl` regional channels and remove duplicate

### DIFF
--- a/data/channels.csv
+++ b/data/channels.csv
@@ -21432,7 +21432,7 @@ OmroepBrabantRadio.nl,Omroep Brabant Radio,,,Omroep Brabant,NL,general,FALSE,,,,
 OmroepCentraalTV.nl,Omroep Centraal TV,,,Omroep Centraal,NL,general,FALSE,,,,https://www.omroepcentraal.nl/
 OmroepDommelland.nl,Omroep Dommelland,,,Omroep Dommelland,NL,general,FALSE,,,,https://www.omroepdommelland.nl/
 OmroepFlevoland.nl,Omroep Flevoland,,,Omroep Flevoland,NL,general,FALSE,,,,https://www.omroepflevoland.nl/
-OmroepGelderland.nl,Omroep Gelderland,,,Omroep Gelderland,NL,general,FALSE,1996-11-01,,,https://www.gld.nl/tv/overzicht
+OmroepGelderland.nl,Omroep Gelderland,,,Omroep Gelderland,NL,general,FALSE,1996-11-01,,,https://www.gld.nl/
 OmroepHoekscheWaard.nl,Omroep Hoeksche Waard,,,Omroep Hoeksche Ward,NL,general,FALSE,,,,https://www.omroephw.nl/
 OmroepHorstaandeMaas.nl,Omroep Horst aan de Maas,,,Omroep Horst aan de Maas,NL,general,FALSE,,,,https://omroephorstaandemaas.nl/
 OmroepHulst.nl,Omroep Hulst,,,Omroep Hulst,NL,general,FALSE,,,,https://www.omroephulst.tv/live/
@@ -29795,7 +29795,6 @@ TVGCativos.es,TVG Cativos,TVG Cativ@s,CRTVG,,ES,kids,FALSE,,,,http://www.crtvg.e
 TVGCultural.es,TVG Cultural,Cultura365,CRTVG,,ES,culture,FALSE,,,,https://www.crtvg.es/cultural
 TVGE.gq,TVGE,,,,GQ,general,FALSE,1968-07-20,,,https://tvgelive.gq/
 TVGEInternacional.gq,TVGE Internacional,,,,GQ,general,FALSE,2011-05-31,,,https://tvgelive.gq/
-TVGelderland.nl,TV Gelderland,,Omroep Gelderland,Omroep Gelderland,NL,,FALSE,1996-11-01,,,https://www.gld.nl/
 TVGerais.br,TV Gerais,,,,BR,general,FALSE,,,,http://www.tvgerais.com.br/
 TVGetsemani.sv,TV Getsemani,TV Getsemaní,,,SV,religious,FALSE,,,,https://www.radiogetsemani.net/
 TVGEvento1.es,TVG Evento 1,TVG Evento,CRTVG,,ES,,FALSE,,,,https://www.crtvg.es/tvg/tvg-en-directo

--- a/data/feeds.csv
+++ b/data/feeds.csv
@@ -22053,6 +22053,7 @@ NGRadioTV.pr,SD,SD,,TRUE,c/PR,America/Puerto_Rico,spa,480i
 NGTV.cm,SD,SD,,TRUE,c/CM,Africa/Douala,fra,576i
 NGTV192.us,SD,SD,,TRUE,ct/USNTG,America/New_York,eng,480i
 Ngwanu.ng,SD,SD,,TRUE,c/NG,Africa/Lagos,ibo;eng,576i
+NH.nl,HD,HD,,FALSE,c/NL,Europe/Amsterdam,nld,1080i
 NH.nl,SD,SD,,TRUE,c/NL,Europe/Amsterdam,nld,576i
 NhanDanTV.vn,SD,SD,,TRUE,c/VN,Asia/Ho_Chi_Minh,vie,576i
 NHCTV.us,SD,SD,,TRUE,ct/USILM,America/New_York,eng,480i
@@ -23015,7 +23016,9 @@ OmroepBrabant.nl,SD,SD,,TRUE,c/NL,Europe/Amsterdam,nld,576i
 OmroepBrabantRadio.nl,SD,SD,,TRUE,c/NL,Europe/Amsterdam,nld,576i
 OmroepCentraalTV.nl,SD,SD,,TRUE,c/NL,Europe/Amsterdam,nld,576i
 OmroepDommelland.nl,SD,SD,,TRUE,c/NL,Europe/Amsterdam,nld,576i
+OmroepFlevoland.nl,HD,HD,,FALSE,c/NL,Europe/Amsterdam,nld,1080i
 OmroepFlevoland.nl,SD,SD,,TRUE,c/NL,Europe/Amsterdam,nld,576i
+OmroepGelderland.nl,HD,HD,,FALSE,c/NL,Europe/Amsterdam,nld,1080i
 OmroepGelderland.nl,SD,SD,,TRUE,c/NL,Europe/Amsterdam,nld,576i
 OmroepHoekscheWaard.nl,SD,SD,,TRUE,c/NL,Europe/Amsterdam,nld,576i
 OmroepHorstaandeMaas.nl,SD,SD,,TRUE,c/NL,Europe/Amsterdam,nld,576i
@@ -26567,6 +26570,7 @@ RTVTotalYurimaguas.pe,SD,SD,,TRUE,c/PE,America/Lima,spa,480i
 RTVU.bo,SD,SD,,TRUE,c/BO,America/La_Paz,spa,576i
 RTVUlpiana.xk,SD,SD,,TRUE,c/XK,Europe/Belgrade,sqi,576i
 RTVUSK.ba,SD,SD,,TRUE,c/BA,Europe/Sarajevo,bos,576i
+RTVUtrecht.nl,HD,HD,,FALSE,c/NL,Europe/Amsterdam,nld,1080i
 RTVUtrecht.nl,SD,SD,,TRUE,c/NL,Europe/Amsterdam,nld,576i
 RTVVeluwezoomTV.nl,SD,SD,,TRUE,c/NL,Europe/Amsterdam,nld,576i
 RTVVida.es,SD,SD,,TRUE,c/ES,Europe/Madrid,spa,576i
@@ -32315,7 +32319,6 @@ TVGCativos.es,SD,SD,,TRUE,c/ES,Europe/Madrid,glg,576i
 TVGCultural.es,SD,SD,,TRUE,c/ES,Europe/Madrid,glg,576i
 TVGE.gq,SD,SD,,TRUE,c/GQ,Africa/Malabo,spa,576i
 TVGEInternacional.gq,SD,SD,,TRUE,r/NORAM;r/EMEA,Africa/Malabo,spa,576i
-TVGelderland.nl,SD,SD,,TRUE,c/NL,Europe/Amsterdam,nld,576i
 TVGerais.br,SD,SD,,TRUE,s/BR-MG,America/Sao_Paulo,por,480i
 TVGetsemani.sv,SD,SD,,TRUE,c/SV,America/El_Salvador,spa,480i
 TVGEvento1.es,SD,SD,,TRUE,c/ES,Europe/Madrid,glg,576i

--- a/data/logos.csv
+++ b/data/logos.csv
@@ -33450,7 +33450,6 @@ TVGCultural.es,,,256,255,PNG,https://i.imgur.com/dvkzH8n.png
 TVGE.gq,,,61,78,PNG,https://i.imgur.com/iOdHgPd.png
 TVGEInternacional.gq,,,112,96,PNG,https://i.imgur.com/nwaiGER.png
 TVGEInternacional.gq,,picons,220,132,PNG,https://i.postimg.cc/P5GtRgsS/tvgeinternacional.png
-TVGelderland.nl,,,64,64,PNG,https://i.imgur.com/1BW6mdw.png
 TVGerais.br,,,180,29,PNG,https://i.imgur.com/6qs1obj.png
 TVGetsemani.sv,,,512,167,JPEG,https://i.imgur.com/C9SJCcE.jpg
 TVGEvento1.es,,,217,226,PNG,https://i.imgur.com/ncxmX63.png


### PR DESCRIPTION
Forgotten 4 regional public broadcasters in relation to https://github.com/iptv-org/database/pull/22331

- `OmroepGelderland.nl`: Added HD feed.
- `OmroepFlevoland.nl`: Added HD feed.
- `NH.nl`: Added HD feed.
- `RTVUtrecht.nl`: Added HD feed.
- `TVGelderland.nl`: Removed, duplicate of `OmroepGelderland.nl`.