### PR TITLE
Fix RTP Notícias logo

### DIFF
--- a/data/logos.csv
+++ b/data/logos.csv
@@ -26416,7 +26416,7 @@ RTPmAmerica.pt,,,1920,240,PNG,https://upload.wikimedia.org/wikipedia/commons/thu
 RTPmAsia.pt,,,1920,240,PNG,https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/RTP_Mundo.svg/1920px-RTP_Mundo.svg.png
 RTPMemoria.pt,,,510,61,PNG,https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/rtpmemoria_2026.png
 RTPMundo.pt,,,1920,240,PNG,https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/RTP_Mundo.svg/1920px-RTP_Mundo.svg.png
-RTPNoticias.pt,,,185,21,PNG,https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/rtpmadeira_2026.png
+RTPNoticias.pt,,,185,21,PNG,https://cdn-images.rtp.pt/common/img/channels/logos/color/horizontal/rtpnoticias_2026.png
 RTPTelevision.co,,,400,400,PNG,https://i.imgur.com/13ARpTZ.png
 RTQQueretaro.mx,,,438,226,PNG,https://i.imgur.com/RRckCvf.png
 RTRBelarus.by,,,399,92,PNG,https://i.imgur.com/FEVPypV.png


### PR DESCRIPTION
In my last PR i accidentally wrote rtpmadeira_2026.png instead of rtpnoticias_2026.png.

This fixes it :)