### PR TITLE
Patch 2026.04.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_channels_add.yml
+++ b/.github/ISSUE_TEMPLATE/01_channels_add.yml
@@ -180,10 +180,21 @@ body:
     validations:
       required: true
 
-  - type: input
-    id: logo_tags
+  - type: dropdown
+    id: in_use
     attributes:
-      label: Logo Tags (optional)
+      label: In Use
+      description: Indicates whether the broadcaster is currently using this logo
+      options:
+        - 'TRUE'
+        - 'FALSE'
+    validations:
+      required: true
+
+  - type: input
+    id: tags
+    attributes:
+      label: Tags (optional)
       description: "List of keywords describing this version of the logo separated by `;`. May include: `a-z`, `0-9` and `-`."
       placeholder: 'horizontal;white'
 

--- a/.github/ISSUE_TEMPLATE/01_channels_add.yml
+++ b/.github/ISSUE_TEMPLATE/01_channels_add.yml
@@ -97,26 +97,6 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Logo
-        Description of the main logo of the channel
-
-  - type: input
-    id: logo_url
-    attributes:
-      label: Logo URL
-      description: "Logo URL. Supported formats: `PNG`, `JPEG`, `SVG`, `GIF`, `WebP`, `AVIF`, `APNG`. Only URLs with [HTTPS](https://ru.wikipedia.org/wiki/HTTPS) protocol are supported. The link should not be [geo-blocked](https://en.wikipedia.org/wiki/Geo-blocking)"
-      placeholder: 'https://example.com/logo.png'
-    validations:
-      required: true
-
-  - type: markdown
-    attributes:
-      value: |
-        `width`, `height` and `format` of the logo will be calculated automatically
-
-  - type: markdown
-    attributes:
-      value: |
         ## Main Feed
         Description of the main feed of the channel
 
@@ -129,6 +109,13 @@ body:
       value: 'SD'
     validations:
       required: true
+
+  - type: input
+    id: feed_alt_names
+    attributes:
+      label: Feed Alternative Names (optional)
+      description: List of alternative feed names separated by `;`. May contain any characters except `,` and `"`
+      placeholder: 'Este'
 
   - type: input
     id: broadcast_area
@@ -178,7 +165,29 @@ body:
     validations:
       required: true
 
+  - type: markdown
+    attributes:
+      value: |
+        ## Logo
+        Description of the main logo of the channel
+
+  - type: input
+    id: logo_url
+    attributes:
+      label: Logo URL
+      description: "Logo URL. Supported formats: `PNG`, `JPEG`, `SVG`, `GIF`, `WebP`, `AVIF`, `APNG`. Only URLs with [HTTPS](https://ru.wikipedia.org/wiki/HTTPS) protocol are supported. The link should not be [geo-blocked](https://en.wikipedia.org/wiki/Geo-blocking)"
+      placeholder: 'https://example.com/logo.png'
+    validations:
+      required: true
+
+  - type: input
+    id: logo_tags
+    attributes:
+      label: Logo Tags (optional)
+      description: "List of keywords describing this version of the logo separated by `;`. May include: `a-z`, `0-9` and `-`."
+      placeholder: 'horizontal;white'
+
   - type: textarea
     attributes:
-      label: Notes
+      label: Notes (optional)
       description: 'Anything else we should know?'

--- a/.github/ISSUE_TEMPLATE/04_feeds_add.yml
+++ b/.github/ISSUE_TEMPLATE/04_feeds_add.yml
@@ -106,10 +106,21 @@ body:
       description: "Logo URL. Supported formats: `PNG`, `JPEG`, `SVG`, `GIF`, `WebP`, `AVIF`, `APNG`. Only URLs with [HTTPS](https://ru.wikipedia.org/wiki/HTTPS) protocol are supported. The link should not be [geo-blocked](https://en.wikipedia.org/wiki/Geo-blocking)"
       placeholder: 'https://example.com/logo.png'
 
-  - type: input
-    id: logo_tags
+  - type: dropdown
+    id: in_use
     attributes:
-      label: Logo Tags (optional)
+      label: In Use
+      description: Indicates whether the broadcaster is currently using this logo
+      options:
+        - 'TRUE'
+        - 'FALSE'
+    validations:
+      required: true
+
+  - type: input
+    id: tags
+    attributes:
+      label: Tags (optional)
       description: "List of keywords describing this version of the logo separated by `;`. May include: `a-z`, `0-9` and `-`."
       placeholder: 'horizontal;white'
 

--- a/.github/ISSUE_TEMPLATE/04_feeds_add.yml
+++ b/.github/ISSUE_TEMPLATE/04_feeds_add.yml
@@ -12,7 +12,7 @@ body:
   - type: input
     id: channel_id
     attributes:
-      label: Channel ID (required)
+      label: Channel ID
       description: ID of the channel to which this feed belongs
       placeholder: 'France3.fr'
     validations:
@@ -30,7 +30,7 @@ body:
   - type: input
     id: alt_name
     attributes:
-      label: Alternative Names
+      label: Alternative Names (optional)
       description: List of alternative feed names separated by `;`. May contain any characters except `,` and `"`
       placeholder: 'Méditerranée;Mediterranean'
 
@@ -93,7 +93,27 @@ body:
     validations:
       required: true
 
+  - type: markdown
+    attributes:
+      value: |
+        ## Logo
+        Description of the logo for this feed
+
+  - type: input
+    id: logo_url
+    attributes:
+      label: Logo URL (optional)
+      description: "Logo URL. Supported formats: `PNG`, `JPEG`, `SVG`, `GIF`, `WebP`, `AVIF`, `APNG`. Only URLs with [HTTPS](https://ru.wikipedia.org/wiki/HTTPS) protocol are supported. The link should not be [geo-blocked](https://en.wikipedia.org/wiki/Geo-blocking)"
+      placeholder: 'https://example.com/logo.png'
+
+  - type: input
+    id: logo_tags
+    attributes:
+      label: Logo Tags (optional)
+      description: "List of keywords describing this version of the logo separated by `;`. May include: `a-z`, `0-9` and `-`."
+      placeholder: 'horizontal;white'
+
   - type: textarea
     attributes:
-      label: Notes
+      label: Notes (optional)
       description: 'Anything else we should know?'

--- a/.github/ISSUE_TEMPLATE/07_logos_add.yml
+++ b/.github/ISSUE_TEMPLATE/07_logos_add.yml
@@ -12,7 +12,7 @@ body:
   - type: input
     id: channel_id
     attributes:
-      label: Channel ID (required)
+      label: Channel ID
       description: ID of the channel to which this logo belongs
       placeholder: 'France3.fr'
     validations:
@@ -21,14 +21,14 @@ body:
   - type: input
     id: feed_id
     attributes:
-      label: Feed ID
+      label: Feed ID (optional)
       description: ID of the feed to which this logo belongs
       placeholder: 'Alpes'
 
   - type: input
     id: logo_url
     attributes:
-      label: Logo URL (required)
+      label: Logo URL
       description: "Logo URL. Supported formats: `PNG`, `JPEG`, `SVG`, `GIF`, `WebP`, `AVIF`, `APNG`. Only URLs with [HTTPS](https://ru.wikipedia.org/wiki/HTTPS) protocol are supported. The link should not be [geo-blocked](https://en.wikipedia.org/wiki/Geo-blocking)."
       placeholder: 'https://example.com/logo.png'
     validations:
@@ -48,16 +48,11 @@ body:
   - type: input
     id: tags
     attributes:
-      label: Tags
+      label: Tags (optional)
       description: "List of keywords describing this version of the logo separated by `;`. May include: `a-z`, `0-9` and `-`."
       placeholder: 'horizontal;white'
 
-  - type: markdown
-    attributes:
-      value: |
-        `width`, `height` and `format` will be calculated automatically
-
   - type: textarea
     attributes:
-      label: Notes
+      label: Notes (optional)
       description: 'Anything else we should know?'

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "@iptv-org/database",
       "license": "UNLICENSED",
       "dependencies": {
+        "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^9.39.3",
         "@freearhey/core": "^0.15.2",
         "@freearhey/storage-js": "^0.2.0",
@@ -150,6 +151,78 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/js": {
@@ -1558,6 +1631,12 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1628,6 +1707,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1669,6 +1757,12 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.4.2",
@@ -2152,15 +2246,16 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -2416,6 +2511,22 @@
         "node": ">= 4"
       }
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2479,6 +2590,18 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/json-buffer": {
@@ -3044,6 +3167,18 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3162,6 +3297,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -3304,6 +3448,18 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/timer-node": {
       "version": "5.0.9",
@@ -4191,6 +4347,56 @@
         "@types/json-schema": "^7.0.15"
       }
     },
+    "@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "requires": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+        },
+        "brace-expansion": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "globals": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+          "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="
+        },
+        "ignore": {
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+          "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
+        },
+        "minimatch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
     "@eslint/js": {
       "version": "9.39.3",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
@@ -5009,6 +5215,11 @@
         "uri-js": "^4.2.2"
       }
     },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
     "assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -5061,6 +5272,11 @@
         "function-bind": "^1.1.2"
       }
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+    },
     "chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -5083,6 +5299,11 @@
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "consola": {
       "version": "3.4.2",
@@ -5386,9 +5607,9 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="
     },
     "follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
     },
     "foreground-child": {
       "version": "3.3.1",
@@ -5538,6 +5759,15 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="
     },
+    "import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -5581,6 +5811,14 @@
         "@hapi/tlds": "^1.1.1",
         "@hapi/topo": "^6.0.2",
         "@standard-schema/spec": "^1.0.0"
+      }
+    },
+    "js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "requires": {
+        "argparse": "^2.0.1"
       }
     },
     "json-buffer": {
@@ -5875,6 +6113,14 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5943,6 +6189,11 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
     "resolve-pkg-maps": {
       "version": "1.0.0",
@@ -6049,6 +6300,11 @@
         }
       }
     },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+    },
     "timer-node": {
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/timer-node/-/timer-node-5.0.9.tgz",
@@ -6095,7 +6351,7 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "requires": {
-        "esbuild": "~0.25.0",
+        "esbuild": "0.23.1",
         "fsevents": "~2.3.3",
         "get-tsconfig": "^4.7.5"
       },
@@ -6257,8 +6513,7 @@
           "optional": true
         },
         "esbuild": {
-          "version": "0.25.12",
-          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+          "version": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
           "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
           "requires": {
             "@esbuild/aix-ppc64": "0.25.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@eslint/js": "^9.39.3",
         "@freearhey/core": "^0.15.2",
         "@freearhey/storage-js": "^0.2.0",
-        "@iptv-org/sdk": "^1.1.3",
+        "@iptv-org/sdk": "^1.3.0",
         "@joi/date": "^2.1.1",
         "@json2csv/formatters": "^7.0.6",
         "@json2csv/node": "^7.0.6",
@@ -302,9 +302,10 @@
       }
     },
     "node_modules/@freearhey/search-js": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@freearhey/search-js/-/search-js-0.2.0.tgz",
-      "integrity": "sha512-1sxfCRbxM12Js3nM/S51cVKLYEjoksERidz539bleMAXes44eTC2m0TEQTJzJyE7l1pw2qUwsIhjd2l2l88fSw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@freearhey/search-js/-/search-js-0.2.1.tgz",
+      "integrity": "sha512-RXVJ2AaXjnrLPpLHCOWrdgtYc4SZplYl905INFmhL6V8jcyIrX+qrjkAjwAHqWDTnJSYfSG9D9Xr+EyKx/eXng==",
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
       },
@@ -439,15 +440,15 @@
       }
     },
     "node_modules/@iptv-org/sdk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@iptv-org/sdk/-/sdk-1.1.3.tgz",
-      "integrity": "sha512-e2IQWPVpNdMJnCkJulnBpiU2Hn5hpaSKNTxo4bvOI4uMRRXR7R8hWbm9jtJnf5LYQ6xdN0xT52EjI0zi9dh5yg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@iptv-org/sdk/-/sdk-1.3.0.tgz",
+      "integrity": "sha512-iSUfH/V6coya2/hoKp8XViQp5tt6DXb/Us9WBPCp7J9TCsKpFmBzFU4kCmBUwxlZDzxxBOpFnqHTxqIW70l4+Q==",
       "license": "UNLICENSED",
       "dependencies": {
         "@freearhey/core": "^0.15.1",
-        "@freearhey/search-js": "^0.2.0",
+        "@freearhey/search-js": "^0.2.1",
         "@ntlab/sfetch": "^1.2.0",
-        "axios": "^1.11.0",
+        "axios": "^1.15.0",
         "dayjs": "^1.11.18"
       }
     },
@@ -4450,9 +4451,9 @@
       }
     },
     "@freearhey/search-js": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@freearhey/search-js/-/search-js-0.2.0.tgz",
-      "integrity": "sha512-1sxfCRbxM12Js3nM/S51cVKLYEjoksERidz539bleMAXes44eTC2m0TEQTJzJyE7l1pw2qUwsIhjd2l2l88fSw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@freearhey/search-js/-/search-js-0.2.1.tgz",
+      "integrity": "sha512-RXVJ2AaXjnrLPpLHCOWrdgtYc4SZplYl905INFmhL6V8jcyIrX+qrjkAjwAHqWDTnJSYfSG9D9Xr+EyKx/eXng==",
       "requires": {
         "lodash": "^4.17.21"
       }
@@ -4543,14 +4544,14 @@
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="
     },
     "@iptv-org/sdk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@iptv-org/sdk/-/sdk-1.1.3.tgz",
-      "integrity": "sha512-e2IQWPVpNdMJnCkJulnBpiU2Hn5hpaSKNTxo4bvOI4uMRRXR7R8hWbm9jtJnf5LYQ6xdN0xT52EjI0zi9dh5yg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@iptv-org/sdk/-/sdk-1.3.0.tgz",
+      "integrity": "sha512-iSUfH/V6coya2/hoKp8XViQp5tt6DXb/Us9WBPCp7J9TCsKpFmBzFU4kCmBUwxlZDzxxBOpFnqHTxqIW70l4+Q==",
       "requires": {
         "@freearhey/core": "^0.15.1",
-        "@freearhey/search-js": "^0.2.0",
+        "@freearhey/search-js": "^0.2.1",
         "@ntlab/sfetch": "^1.2.0",
-        "axios": "^1.11.0",
+        "axios": "^1.15.0",
         "dayjs": "^1.11.18"
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@eslint/js": "^9.39.3",
     "@freearhey/core": "^0.15.2",
     "@freearhey/storage-js": "^0.2.0",
-    "@iptv-org/sdk": "^1.1.3",
+    "@iptv-org/sdk": "^1.3.0",
     "@joi/date": "^2.1.1",
     "@json2csv/formatters": "^7.0.6",
     "@json2csv/node": "^7.0.6",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     ]
   },
   "dependencies": {
+    "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^9.39.3",
     "@freearhey/core": "^0.15.2",
     "@freearhey/storage-js": "^0.2.0",
@@ -51,5 +52,8 @@
     "tsx": "4.20.6",
     "typescript": "^5.9.3",
     "vitest": "^4.1.3"
+  },
+  "overrides": {
+    "esbuild": "0.23.1"
   }
 }

--- a/scripts/commands/db/update.ts
+++ b/scripts/commands/db/update.ts
@@ -221,7 +221,8 @@ async function addChannel(issue: Issue) {
   const newLogo = new Logo({
     channel: newChannel.id,
     feed: null,
-    tags: issueData.getArray('logo_tags'),
+    in_use: issueData.getBoolean('in_use'),
+    tags: issueData.getArray('tags'),
     width: imageInfo.width,
     height: imageInfo.height,
     format: imageInfo.format,
@@ -394,7 +395,8 @@ async function addFeed(issue: Issue) {
     const newLogo = new Logo({
       channel: channelId,
       feed: feedId,
-      tags: issueData.getArray('logo_tags'),
+      in_use: issueData.getBoolean('in_use'),
+      tags: issueData.getArray('tags'),
       width: imageInfo.width,
       height: imageInfo.height,
       format: imageInfo.format,

--- a/scripts/commands/db/update.ts
+++ b/scripts/commands/db/update.ts
@@ -205,7 +205,7 @@ async function addChannel(issue: Issue) {
     channel: newChannel.id,
     id: createFeedId(feedName),
     name: feedName,
-    alt_names: [],
+    alt_names: issueData.getArray('feed_alt_names'),
     is_main: true,
     broadcast_area: broadcastArea,
     timezones: timezones,
@@ -221,7 +221,7 @@ async function addChannel(issue: Issue) {
   const newLogo = new Logo({
     channel: newChannel.id,
     feed: null,
-    tags: [],
+    tags: issueData.getArray('logo_tags'),
     width: imageInfo.width,
     height: imageInfo.height,
     format: imageInfo.format,
@@ -387,6 +387,21 @@ async function addFeed(issue: Issue) {
   log.info(`Feed with id "${feedId}" and channel "${channelId}" added`)
 
   if (newFeed.is_main === true) onFeedNewMain(channelId, feedId, log)
+
+  const logoUrl = issueData.getString('logo_url')
+  if (logoUrl) {
+    const imageInfo = await probeImage(logoUrl)
+    const newLogo = new Logo({
+      channel: channelId,
+      feed: feedId,
+      tags: issueData.getArray('logo_tags'),
+      width: imageInfo.width,
+      height: imageInfo.height,
+      format: imageInfo.format,
+      url: logoUrl
+    })
+    data.logos.add(newLogo)
+  }
 
   const errors = newFeed.validate()
   if (errors.isNotEmpty()) {

--- a/scripts/core/utils.ts
+++ b/scripts/core/utils.ts
@@ -88,6 +88,7 @@ export async function loadIssues(props?: {
       'Channel ID': 'channel_id',
       'Channel Name': 'channel_name',
       'Feed Name': 'feed_name',
+      'Feed Alternative Names': 'feed_alt_names',
       'Feed ID': 'feed_id',
       'Main Feed': 'is_main',
       'Alternative Names': 'alt_names',
@@ -118,7 +119,8 @@ export async function loadIssues(props?: {
       'City Name': 'city_name',
       'City Code': 'city_code',
       'Wikidata ID': 'wikidata_id',
-      'In Use': 'in_use'
+      'In Use': 'in_use',
+      'Logo Tags': 'logo_tags'
     })
 
     const fields = typeof issue.body === 'string' ? issue.body.split('###') : []

--- a/scripts/core/utils.ts
+++ b/scripts/core/utils.ts
@@ -119,8 +119,7 @@ export async function loadIssues(props?: {
       'City Name': 'city_name',
       'City Code': 'city_code',
       'Wikidata ID': 'wikidata_id',
-      'In Use': 'in_use',
-      'Logo Tags': 'logo_tags'
+      'In Use': 'in_use'
     })
 
     const fields = typeof issue.body === 'string' ? issue.body.split('###') : []

--- a/scripts/models/logo.ts
+++ b/scripts/models/logo.ts
@@ -8,7 +8,6 @@ import Joi from 'joi'
 
 export class Logo extends sdk.Models.Logo implements Validator {
   line: number = -1
-  in_use: boolean = true
 
   static fromRow(row: CSVRow): Logo {
     if (!row.data.channel) throw new Error('Logo: "channel" not specified')
@@ -17,6 +16,7 @@ export class Logo extends sdk.Models.Logo implements Validator {
     const logo = new Logo({
       channel: row.data.channel.toString(),
       feed: row.data.feed ? row.data.feed.toString() : null,
+      in_use: row.data.in_use === false ? row.data.in_use : true,
       url: row.data.url.toString(),
       tags: Array.isArray(row.data.tags) ? row.data.tags : [],
       width: typeof row.data.width === 'number' ? row.data.width : 0,
@@ -25,7 +25,6 @@ export class Logo extends sdk.Models.Logo implements Validator {
     })
 
     logo.line = row.line
-    logo.in_use = row.data.in_use === false ? row.data.in_use : true
 
     return logo
   }

--- a/tests/__data__/expected/db/update/data/feeds.csv
+++ b/tests/__data__/expected/db/update/data/feeds.csv
@@ -17,7 +17,7 @@ TrueCrime.uk,Plus1,+1,,FALSE,c/UK,Europe/London,eng,576i
 TrueCrime.uk,SD,SD,,TRUE,c/UK;c/IE,Europe/London,eng,576i
 WenzhouEconomicandEducation.cn,SD,SD,,TRUE,c/CN,Africa/Johannesburg;Africa/Kigali,zho,576i
 YiwuBusinessChannel.cn,SD,SD,,TRUE,c/CN,Africa/Johannesburg;Africa/Kigali,zho,576i
-YiwuNewsIntegratedChannel.cn,SD,SD,,TRUE,c/CN,Africa/Johannesburg;Africa/Kigali,zho,576i
+YiwuNewsIntegratedChannel.cn,SD,SD,A;B,TRUE,c/CN,Africa/Johannesburg;Africa/Kigali,zho,576i
 ZonaDAZN3.it,HD,HD,,TRUE,c/IT,Europe/Rome,ita,576i
 ZonaDAZN3.it,SD,SD,,FALSE,c/IT,Europe/Rome,ita,576i
 ZTVWorld.hu,SD,SD,,TRUE,c/HU,Europe/London,eng,576i

--- a/tests/__data__/expected/db/update/data/logos.csv
+++ b/tests/__data__/expected/db/update/data/logos.csv
@@ -1,5 +1,6 @@
 channel,feed,in_use,tags,width,height,format,url
 01TV.fr,HD,TRUE,,512,512,PNG,https://i.imgur.com/aR5q6mA.png
+1000xHoraTV.uy,HD,TRUE,white,80,80,JPEG,https://i.imgur.com/1ACe9zC.png
 24HorasInternacional.es,,TRUE,light;2006;on-screen,80,80,JPEG,https://i.imgur.com/IUVRm5L.png
 7alaTV.ps,,TRUE,deprecated,400,400,PNG,https://upload.wikimedia.org/wikipedia/commons/7/71/Nothing_whitespace_blank.png
 Baladna.ps,SD,TRUE,deprecated,400,400,PNG,https://upload.wikimedia.org/wikipedia/commons/7/71/Nothing_whitespace_blank.png
@@ -10,8 +11,8 @@ K04JRD1.us,,TRUE,,0,0,PNG,https://upload.wikimedia.org/wikipedia/en/thumb/3/33/P
 K05FWD1.us,,TRUE,,0,0,PNG,https://upload.wikimedia.org/wikipedia/en/thumb/3/33/PBS_logo.svg/512px-PBS_logo.svg.png
 M5.hu,HD,TRUE,,512,512,PNG,https://i.imgur.com/y21wFd0.png
 WenzhouEconomicandEducation.cn,,TRUE,,80,80,JPEG,https://www.tvchinese.net/uploads/tv/wzjjkj.jpg
-YiwuBusinessChannel.cn,,TRUE,,80,80,JPEG,https://www.tvchinese.net/uploads/tv/yiwutv.jpg
-YiwuNewsIntegratedChannel.cn,,TRUE,,80,80,JPEG,https://www.tvchinese.net/uploads/tv/yiwutv.jpg
+YiwuBusinessChannel.cn,,TRUE,horizontal;color,80,80,JPEG,https://www.tvchinese.net/uploads/tv/yiwutv.jpg
+YiwuNewsIntegratedChannel.cn,,TRUE,horizontal,80,80,JPEG,https://www.tvchinese.net/uploads/tv/yiwutv.jpg
 ZonaDAZN3.it,HD,TRUE,,400,400,PNG,https://i.imgur.com/Jop3Vip.png
 ZTVWorld.hu,,TRUE,,0,0,PNG,https://i.imgur.com/wPqCtwR.png
 ZutTV.ve,HD,TRUE,,0,0,PNG,https://i.imgur.com/wPqCtwK.png

--- a/tests/__data__/expected/db/update/data/logos.csv
+++ b/tests/__data__/expected/db/update/data/logos.csv
@@ -1,6 +1,6 @@
 channel,feed,in_use,tags,width,height,format,url
 01TV.fr,HD,TRUE,,512,512,PNG,https://i.imgur.com/aR5q6mA.png
-1000xHoraTV.uy,HD,TRUE,white,80,80,JPEG,https://i.imgur.com/1ACe9zC.png
+1000xHoraTV.uy,HD,FALSE,white,80,80,JPEG,https://i.imgur.com/1ACe9zC.png
 24HorasInternacional.es,,TRUE,light;2006;on-screen,80,80,JPEG,https://i.imgur.com/IUVRm5L.png
 7alaTV.ps,,TRUE,deprecated,400,400,PNG,https://upload.wikimedia.org/wikipedia/commons/7/71/Nothing_whitespace_blank.png
 Baladna.ps,SD,TRUE,deprecated,400,400,PNG,https://upload.wikimedia.org/wikipedia/commons/7/71/Nothing_whitespace_blank.png
@@ -12,7 +12,7 @@ K05FWD1.us,,TRUE,,0,0,PNG,https://upload.wikimedia.org/wikipedia/en/thumb/3/33/P
 M5.hu,HD,TRUE,,512,512,PNG,https://i.imgur.com/y21wFd0.png
 WenzhouEconomicandEducation.cn,,TRUE,,80,80,JPEG,https://www.tvchinese.net/uploads/tv/wzjjkj.jpg
 YiwuBusinessChannel.cn,,TRUE,horizontal;color,80,80,JPEG,https://www.tvchinese.net/uploads/tv/yiwutv.jpg
-YiwuNewsIntegratedChannel.cn,,TRUE,horizontal,80,80,JPEG,https://www.tvchinese.net/uploads/tv/yiwutv.jpg
+YiwuNewsIntegratedChannel.cn,,FALSE,horizontal,80,80,JPEG,https://www.tvchinese.net/uploads/tv/yiwutv.jpg
 ZonaDAZN3.it,HD,TRUE,,400,400,PNG,https://i.imgur.com/Jop3Vip.png
 ZTVWorld.hu,,TRUE,,0,0,PNG,https://i.imgur.com/wPqCtwR.png
 ZutTV.ve,HD,TRUE,,0,0,PNG,https://i.imgur.com/wPqCtwK.png

--- a/tests/__data__/input/db/update/issues.js
+++ b/tests/__data__/input/db/update/issues.js
@@ -219,7 +219,7 @@ module.exports = [
     closed_at: null,
     author_association: 'CONTRIBUTOR',
     active_lock_reason: null,
-    body: '### Channel Name\n\nYiwu News Integrated Channel\n\n### Alternative Names (optional)\n\n_No response_\n\n### Network (optional)\n\n_No response_\n\n### Owners (optional)\n\n_No response_\n\n### Country\n\nCN\n\n### Subdivision (optional)\n\n_No response_\n\n### City (optional)\n\n_No response_\n\n### Categories (optional)\n\nnews\n\n### NSFW\n\nFALSE\n\n### Launched (optional)\n\n_No response_\n\n### Closed (optional)\n\n_No response_\n\n### Replaced By (optional)\n\n_No response_\n\n### Website (optional)\n\n_No response_\n\n### Logo URL\n\nhttps://www.tvchinese.net/uploads/tv/yiwutv.jpg\n\n### Feed Name\n\nSD\n\n### Broadcast Area\n\nc/CN\n\n### Languages\n\nzho\n\n### Timezones\n\nAfrica/Johannesburg;Africa/Kigali\n\n### Format\n\n576i\n\n### Notes\n\n_No response_',
+    body: '### Channel Name\n\nYiwu News Integrated Channel\n\n### Alternative Names (optional)\n\n_No response_\n\n### Network (optional)\n\n_No response_\n\n### Owners (optional)\n\n_No response_\n\n### Country\n\nCN\n\n### Subdivision (optional)\n\n_No response_\n\n### City (optional)\n\n_No response_\n\n### Categories (optional)\n\nnews\n\n### NSFW\n\nFALSE\n\n### Launched (optional)\n\n_No response_\n\n### Closed (optional)\n\n_No response_\n\n### Replaced By (optional)\n\n_No response_\n\n### Website (optional)\n\n_No response_\n\n### Feed Name\n\nSD\n\n### Feed Alternative Names\n\nA;B\n\n### Broadcast Area\n\nc/CN\n\n### Languages\n\nzho\n\n### Timezones\n\nAfrica/Johannesburg;Africa/Kigali\n\n### Format\n\n576i\n\n### Logo URL\n\nhttps://www.tvchinese.net/uploads/tv/yiwutv.jpg\n\n### Logo Tags\n\nhorizontal\n\n### Notes\n\n_No response_',
     reactions: {
       url: 'https://api.github.com/repos/iptv-org/database/issues/5900/reactions',
       total_count: 0,
@@ -298,7 +298,7 @@ module.exports = [
     closed_at: null,
     author_association: 'CONTRIBUTOR',
     active_lock_reason: null,
-    body: '### Channel Name\n\nYiwu Business Channel\n\n### Alternative Names (optional)\n\n_No response_\n\n### Network (optional)\n\n_No response_\n\n### Owners (optional)\n\n_No response_\n\n### Country\n\nCN\n\n### Subdivision (optional)\n\n_No response_\n\n### City (optional)\n\n_No response_\n\n### Categories (optional)\n\nbusiness\n\n### NSFW\n\nFALSE\n\n### Launched (optional)\n\n_No response_\n\n### Closed (optional)\n\n_No response_\n\n### Replaced By (optional)\n\n_No response_\n\n### Website (optional)\n\n_No response_\n\n### Logo URL\n\nhttps://www.tvchinese.net/uploads/tv/yiwutv.jpg\n\n### Feed Name\n\nSD\n\n### Broadcast Area\n\nc/CN\n\n### Languages\n\nzho\n\n### Timezones\n\nAfrica/Johannesburg;Africa/Kigali\n\n### Format\n\n576i\n\n### Notes\n\n_No response_',
+    body: '### Channel Name\n\nYiwu Business Channel\n\n### Alternative Names (optional)\n\n_No response_\n\n### Network (optional)\n\n_No response_\n\n### Owners (optional)\n\n_No response_\n\n### Country\n\nCN\n\n### Subdivision (optional)\n\n_No response_\n\n### City (optional)\n\n_No response_\n\n### Categories (optional)\n\nbusiness\n\n### NSFW\n\nFALSE\n\n### Launched (optional)\n\n_No response_\n\n### Closed (optional)\n\n_No response_\n\n### Replaced By (optional)\n\n_No response_\n\n### Website (optional)\n\n_No response_\n\n### Logo URL\n\nhttps://www.tvchinese.net/uploads/tv/yiwutv.jpg\n\n### Logo Tags\n\nhorizontal;color\n\n### Feed Name\n\nSD\n\n### Broadcast Area\n\nc/CN\n\n### Languages\n\nzho\n\n### Timezones\n\nAfrica/Johannesburg;Africa/Kigali\n\n### Format\n\n576i\n\n### Notes\n\n_No response_',
     reactions: {
       url: 'https://api.github.com/repos/iptv-org/database/issues/5899/reactions',
       total_count: 0,
@@ -851,7 +851,7 @@ module.exports = [
     closed_at: null,
     author_association: 'CONTRIBUTOR',
     active_lock_reason: null,
-    body: '### Channel ID\n\n1000xHoraTV.uy\n\n### Feed Name\n\nHD\n\n### Alternative Names\n\nOeste;Este\n\n### Main Feed\n\nTRUE\n\n### Broadcast Area\n\nc/CN\n\n### Languages\n\nzho\n\n### Timezones\n\nAfrica/Johannesburg;Africa/Kigali\n\n### Format\n\n576i\n\n### Notes\n\n_No response_',
+    body: '### Channel ID\n\n1000xHoraTV.uy\n\n### Feed Name\n\nHD\n\n### Alternative Names\n\nOeste;Este\n\n### Main Feed\n\nTRUE\n\n### Broadcast Area\n\nc/CN\n\n### Languages\n\nzho\n\n### Timezones\n\nAfrica/Johannesburg;Africa/Kigali\n\n### Format\n\n576i\n\n### Logo URL\n\nhttps://i.imgur.com/1ACe9zC.png\n\n### Logo Tags\n\nwhite\n\n### Notes\n\n_No response_',
     reactions: {
       url: 'https://api.github.com/repos/iptv-org/database/issues/8900/reactions',
       total_count: 0,

--- a/tests/__data__/input/db/update/issues.js
+++ b/tests/__data__/input/db/update/issues.js
@@ -219,7 +219,7 @@ module.exports = [
     closed_at: null,
     author_association: 'CONTRIBUTOR',
     active_lock_reason: null,
-    body: '### Channel Name\n\nYiwu News Integrated Channel\n\n### Alternative Names (optional)\n\n_No response_\n\n### Network (optional)\n\n_No response_\n\n### Owners (optional)\n\n_No response_\n\n### Country\n\nCN\n\n### Subdivision (optional)\n\n_No response_\n\n### City (optional)\n\n_No response_\n\n### Categories (optional)\n\nnews\n\n### NSFW\n\nFALSE\n\n### Launched (optional)\n\n_No response_\n\n### Closed (optional)\n\n_No response_\n\n### Replaced By (optional)\n\n_No response_\n\n### Website (optional)\n\n_No response_\n\n### Feed Name\n\nSD\n\n### Feed Alternative Names\n\nA;B\n\n### Broadcast Area\n\nc/CN\n\n### Languages\n\nzho\n\n### Timezones\n\nAfrica/Johannesburg;Africa/Kigali\n\n### Format\n\n576i\n\n### Logo URL\n\nhttps://www.tvchinese.net/uploads/tv/yiwutv.jpg\n\n### Logo Tags\n\nhorizontal\n\n### Notes\n\n_No response_',
+    body: '### Channel Name\n\nYiwu News Integrated Channel\n\n### Alternative Names (optional)\n\n_No response_\n\n### Network (optional)\n\n_No response_\n\n### Owners (optional)\n\n_No response_\n\n### Country\n\nCN\n\n### Subdivision (optional)\n\n_No response_\n\n### City (optional)\n\n_No response_\n\n### Categories (optional)\n\nnews\n\n### NSFW\n\nFALSE\n\n### Launched (optional)\n\n_No response_\n\n### Closed (optional)\n\n_No response_\n\n### Replaced By (optional)\n\n_No response_\n\n### Website (optional)\n\n_No response_\n\n### Feed Name\n\nSD\n\n### Feed Alternative Names\n\nA;B\n\n### Broadcast Area\n\nc/CN\n\n### Languages\n\nzho\n\n### Timezones\n\nAfrica/Johannesburg;Africa/Kigali\n\n### Format\n\n576i\n\n### Logo URL\n\nhttps://www.tvchinese.net/uploads/tv/yiwutv.jpg\n\n### In Use\n\nFALSE\n\n### Tags\n\nhorizontal\n\n### Notes\n\n_No response_',
     reactions: {
       url: 'https://api.github.com/repos/iptv-org/database/issues/5900/reactions',
       total_count: 0,
@@ -298,7 +298,7 @@ module.exports = [
     closed_at: null,
     author_association: 'CONTRIBUTOR',
     active_lock_reason: null,
-    body: '### Channel Name\n\nYiwu Business Channel\n\n### Alternative Names (optional)\n\n_No response_\n\n### Network (optional)\n\n_No response_\n\n### Owners (optional)\n\n_No response_\n\n### Country\n\nCN\n\n### Subdivision (optional)\n\n_No response_\n\n### City (optional)\n\n_No response_\n\n### Categories (optional)\n\nbusiness\n\n### NSFW\n\nFALSE\n\n### Launched (optional)\n\n_No response_\n\n### Closed (optional)\n\n_No response_\n\n### Replaced By (optional)\n\n_No response_\n\n### Website (optional)\n\n_No response_\n\n### Logo URL\n\nhttps://www.tvchinese.net/uploads/tv/yiwutv.jpg\n\n### Logo Tags\n\nhorizontal;color\n\n### Feed Name\n\nSD\n\n### Broadcast Area\n\nc/CN\n\n### Languages\n\nzho\n\n### Timezones\n\nAfrica/Johannesburg;Africa/Kigali\n\n### Format\n\n576i\n\n### Notes\n\n_No response_',
+    body: '### Channel Name\n\nYiwu Business Channel\n\n### Alternative Names (optional)\n\n_No response_\n\n### Network (optional)\n\n_No response_\n\n### Owners (optional)\n\n_No response_\n\n### Country\n\nCN\n\n### Subdivision (optional)\n\n_No response_\n\n### City (optional)\n\n_No response_\n\n### Categories (optional)\n\nbusiness\n\n### NSFW\n\nFALSE\n\n### Launched (optional)\n\n_No response_\n\n### Closed (optional)\n\n_No response_\n\n### Replaced By (optional)\n\n_No response_\n\n### Website (optional)\n\n_No response_\n\n### Logo URL\n\nhttps://www.tvchinese.net/uploads/tv/yiwutv.jpg\n\n### Tags\n\nhorizontal;color\n\n### Feed Name\n\nSD\n\n### Broadcast Area\n\nc/CN\n\n### Languages\n\nzho\n\n### Timezones\n\nAfrica/Johannesburg;Africa/Kigali\n\n### Format\n\n576i\n\n### Notes\n\n_No response_',
     reactions: {
       url: 'https://api.github.com/repos/iptv-org/database/issues/5899/reactions',
       total_count: 0,
@@ -851,7 +851,7 @@ module.exports = [
     closed_at: null,
     author_association: 'CONTRIBUTOR',
     active_lock_reason: null,
-    body: '### Channel ID\n\n1000xHoraTV.uy\n\n### Feed Name\n\nHD\n\n### Alternative Names\n\nOeste;Este\n\n### Main Feed\n\nTRUE\n\n### Broadcast Area\n\nc/CN\n\n### Languages\n\nzho\n\n### Timezones\n\nAfrica/Johannesburg;Africa/Kigali\n\n### Format\n\n576i\n\n### Logo URL\n\nhttps://i.imgur.com/1ACe9zC.png\n\n### Logo Tags\n\nwhite\n\n### Notes\n\n_No response_',
+    body: '### Channel ID\n\n1000xHoraTV.uy\n\n### Feed Name\n\nHD\n\n### Alternative Names\n\nOeste;Este\n\n### Main Feed\n\nTRUE\n\n### Broadcast Area\n\nc/CN\n\n### Languages\n\nzho\n\n### Timezones\n\nAfrica/Johannesburg;Africa/Kigali\n\n### Format\n\n576i\n\n### Logo URL\n\nhttps://i.imgur.com/1ACe9zC.png\n\n### In Use\n\nFALSE\n\n### Tags\n\nwhite\n\n### Notes\n\n_No response_',
     reactions: {
       url: 'https://api.github.com/repos/iptv-org/database/issues/8900/reactions',
       total_count: 0,


### PR DESCRIPTION
Changes:

- the optional fields "Logo URL", "In Use" and "Tags" have been added to the `feeds:add` form ([preview](https://github.com/iptv-org/database/blob/patch-2026.04.2/.github/ISSUE_TEMPLATE/04_feeds_add.yml))
- the optional fields "Feed Alternative Names", "In Use" and "Tags" have been added to the `channels:add` form ([preview](https://github.com/iptv-org/database/blob/patch-2026.04.2/.github/ISSUE_TEMPLATE/01_channels_add.yml))

Test results:

```sh
npm test                 

> test
> npx vitest run --no-file-parallelism

 ✓ tests/commands/db/validate.test.ts (5 tests) 8015ms
     ✓ shows an error if the number of columns in a row is incorrect  1552ms
     ✓ shows an error if one of the lines ends with an invalid character  1606ms
     ✓ shows an error if there are duplicates in the file  1636ms
     ✓ shows an error if the data contains an error  1620ms
     ✓ does not show an error if all data are correct  1596ms
(node:34023) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
(Use `node --trace-warnings ...` to show where the warning was created)
 ✓ tests/commands/db/check_logos.test.ts (8 tests) 6306ms
     ✓ retries and gives up on persistent 429  6026ms
 ✓ tests/commands/db/export.test.ts (1 test) 1605ms
     ✓ can export data as json  1602ms
 ✓ tests/commands/db/update.test.ts (1 test) 1780ms
     ✓ can update db with data from issues  1777ms

 Test Files  4 passed (4)
      Tests  15 passed (15)
   Duration  18.97s (transform 115ms, setup 0ms, import 379ms, tests 17.71s, environment 1ms)
```