### PR TITLE
ITV1.uk: Add Border +1

### DIFF
--- a/data/feeds.csv
+++ b/data/feeds.csv
@@ -13081,11 +13081,11 @@ ITV.ua,SD,SD,,TRUE,c/UA,Europe/Kyiv,ukr,576i
 ITV1.uk,Anglia,Anglia,,FALSE,c/UK,Europe/London,eng,576i
 ITV1.uk,AngliaHD,Anglia HD,,FALSE,c/UK,Europe/London,eng,1080i
 ITV1.uk,AngliaPlus1,Anglia +1,,FALSE,c/UK,Europe/London,eng,576i
-ITV1.uk,BorderEngland,Border England,,FALSE,c/UK,America/Winnipeg,eng,576i
-ITV1.uk,BorderHD,Border HD,,FALSE,c/UK,America/Winnipeg,eng,1080i
+ITV1.uk,BorderEngland,Border England,,FALSE,c/UK,Europe/London,eng,576i
+ITV1.uk,BorderHD,Border HD,,FALSE,c/UK,Europe/London,eng,1080i
 ITV1.uk,BorderPlus1,Border +1,,FALSE,c/UK,Europe/London,eng,576i
-ITV1.uk,BorderScotland,Border Scotland,,FALSE,c/UK,America/Winnipeg,eng,576i
-ITV1.uk,BorderScotlandHD,Border Scotland HD,,FALSE,c/UK,America/Winnipeg,eng,1080i
+ITV1.uk,BorderScotland,Border Scotland,,FALSE,c/UK,Europe/London,eng,576i
+ITV1.uk,BorderScotlandHD,Border Scotland HD,,FALSE,c/UK,Europe/London,eng,1080i
 ITV1.uk,Central,Central,,FALSE,c/UK,Europe/London,eng,576i
 ITV1.uk,CentralHD,Central HD,,FALSE,c/UK,Europe/London,eng,1080i
 ITV1.uk,CentralPlus1,Central +1,,FALSE,c/UK,Europe/London,eng,576i

--- a/data/feeds.csv
+++ b/data/feeds.csv
@@ -13083,6 +13083,7 @@ ITV1.uk,AngliaHD,Anglia HD,,FALSE,c/UK,Europe/London,eng,1080i
 ITV1.uk,AngliaPlus1,Anglia +1,,FALSE,c/UK,Europe/London,eng,576i
 ITV1.uk,BorderEngland,Border England,,FALSE,c/UK,America/Winnipeg,eng,576i
 ITV1.uk,BorderHD,Border HD,,FALSE,c/UK,America/Winnipeg,eng,1080i
+ITV1.uk,BorderPlus1,Border +1,,FALSE,c/UK,Europe/London,eng,576i
 ITV1.uk,BorderScotland,Border Scotland,,FALSE,c/UK,America/Winnipeg,eng,576i
 ITV1.uk,BorderScotlandHD,Border Scotland HD,,FALSE,c/UK,America/Winnipeg,eng,1080i
 ITV1.uk,Central,Central,,FALSE,c/UK,Europe/London,eng,576i


### PR DESCRIPTION
ITV1 Border has the same plus one feed for both England and Scotland, so no need to separate them