### PR TITLE
fix: remove broken logo for Goldmines Bollywood

### DIFF
--- a/data/logos.csv
+++ b/data/logos.csv
@@ -10585,7 +10585,6 @@ Goldmines.in,,TRUE,,1770,662,PNG,https://ltsk-cdn.s3.eu-west-1.amazonaws.com/jum
 Goldmines.in,,TRUE,,577,416,PNG,https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_GOLDMINES/images/LOGO_HD/image.png
 Goldmines2.in,,TRUE,,132,99,PNG,https://www.lyngsat.com/logo/tv/gg/goldmines-2-in.png
 GoldminesBollywood.in,,TRUE,color,3200,2400,PNG,https://i.imgur.com/6mNQ9mM.png
-GoldminesBollywood.in,,TRUE,,132,99,PNG,https://www.lyngsat.com/logo/tv/gg/goldmines-bollywood-in.png
 GoldminesMovies.in,,TRUE,,720,540,PNG,https://dtil.tmsimg.com/assets/s142881_ld_h15_aa.png?lock=720x540
 GoldminesMovies.in,,TRUE,,2000,1125,PNG,https://dvdh7g0f0hwck.cloudfront.net/assets/images/channel/GoldminesMovies_Transparent_9b7db248-999e-4200-a459-6cc594650f3d.png
 GoldstarTV.de,,TRUE,,265,207,PNG,https://i.imgur.com/4ySO71h.png


### PR DESCRIPTION
This PR removes the logo URL for Goldmines Bollywood (Channel ID: GoldminesBollywood.in) as it was reported as not loading in issue #27416.

Changes:
Removed the broken logo link: https://www.lyngsat.com/logo/tv/gg/goldmines-bollywood-in.png

Related Issue:
Closes #27416 

Screenshots
N / A