### PR TITLE
Add VinTV.pt and closure of Biggs.pt

### DIFF
--- a/data/channels.csv
+++ b/data/channels.csv
@@ -3015,7 +3015,7 @@ BigCityTV.us,Big City TV,,,Asylum Entertainment Group,US,entertainment,FALSE,,,,
 BIGCivicChannel.us,BIG Civic Channel,Brookline Interactive Group Civic Channel,,,US,general,FALSE,,,,http://brookline-interactive-group.cablecast.tv:8080/CablecastPublicSite/watch/2?channel=2
 BIGCommunityChannel.us,BIG Community Channel,Brookline Interactive Group Community Channel,,,US,general,FALSE,,,,https://brooklineinteractive.org/live/
 BigGangaTalkies.in,Big Ganga Talkies,,,,IN,,FALSE,,,,
-Biggs.pt,Biggs,,,NOS SGPS S.A.;AMC Networks Inc.,PT,kids,FALSE,2009-12-01,,,http://biggs.pt/
+Biggs.pt,Biggs,,,NOS SGPS S.A.;AMC Networks Inc.,PT,kids,FALSE,2009-12-01,2026-05-04,VinTV,http://biggs.pt/
 BigiBetEPL.ng,BigiBet EPL,,,,NG,,FALSE,,,,https://www.bigibet.com/
 BigiBetLaLiga.ng,BigiBet LaLiga,,,,NG,sports,FALSE,,,,https://www.bigibet.com/
 BigiBetLucky6.ng,BigiBet Lucky 6,,,,NG,,FALSE,,,,https://www.bigibet.com/
@@ -32876,6 +32876,7 @@ VinhPhucTV.vn,Vinh Phuc TV,,,,VN,,FALSE,,,,http://vinhphuctv.vn/
 VinilosTV.pe,Vinilos TV,,,,PE,music,FALSE,2023-06-01,,,https://playmax.tv/
 VintageMusic.cr,Vintage Music,,,,CR,music,FALSE,,,,
 VinTV.es,VinTV,Vintage Televisión,,AMC Networks International Southern Europe,ES,series,FALSE,2025-07-01,,,https://amcchannels.es/vintv
+VinTV.pt,VinTV,Biggs,,NOS, SGPS S.A.;AMC Networks Inc.,PT,series,FALSE,2026-05-04,,,https://vintv.pt/
 VinxTV.es,Vinx TV,,,,ES,sports,FALSE,,,,https://www.vinxtv.es/
 VIOTV.sk,VIO TV,,,,SK,,FALSE,,,,http://viotv.sk/
 VIPNews.in,VIP News,,,Crystal Business System Ltd,IN,news,FALSE,,,,

--- a/data/channels.csv
+++ b/data/channels.csv
@@ -936,7 +936,6 @@ AkwaabaMagicAbusua.gh,Akwaaba Magic Abusua,,,M-Net,GH,general,FALSE,2021-03-08,,
 AkwasiAwuaTV.gh,Akwasi Awua TV,,,,GH,religious,FALSE,,,,http://akwasiawuahonline.com/
 AL24News.dz,AL24 News,قناة الجزائر الدولية,,,DZ,news,FALSE,2021-11-01,,,https://al24news.com/
 AlAanTV.ae,Al Aan TV,Alaan TV;تلفزيون الآن,,Tower Media Middle East,AE,news,FALSE,2006-01-01,,,https://www.alaan.tv/
-AlabbassiaTV.iq,Alabbassia TV,,,,IQ,religious,FALSE,,,,https://alabbassia.com
 AlacantiTV.es,Alacanti TV,Alacantí TV,,,ES,general,FALSE,,,,https://alacantitv.com/
 AlacocinaTV.pe,Alacocina TV,,,,PE,entertainment,FALSE,,,,https://www.alacocinatv.com/
 AlafiaTV.ml,Alafia TV,,,,ML,general,FALSE,,,,
@@ -9243,7 +9242,6 @@ Flix.us,Flix,,Paramount+ with SHOWTIME,Showtime Networks Inc.;Paramount Skydance
 FlixFling.us,FlixFling,,,,US,movies,FALSE,,,,https://www.flixfling.com/contact
 FlixSnip.ru,FlixSnip,,,Time Media Group,RU,movies,FALSE,,,,https://flixsnip.com/
 Flooxer.es,Flooxer,,Atresplayer,Atresmedia Corporación de Medios de Comunicación SA,ES,entertainment;series,FALSE,,,,https://www.atresplayer.com/flooxer/
-FloRacing.us,FloRacing,FloRacing 24/7,FloSports,FloSports Inc.,US,sports,FALSE,2025-12-08,,,https://flosports.tv/
 FlorissantCityTV.us,Florissant City TV,,,,US,legislative,FALSE,,,,https://www.florissantmo.com/department/index.php?structureid=48
 FlouCine.us,Flou Cine,,,Canela Media Inc,US,movies,FALSE,,,,https://www.canela.tv/linear/flou-cine
 FlowChannel105.dm,Flow Channel 105,,,C&W Communications Plc.,DM,entertainment,FALSE,,,,https://discoverflow.co/web/dominica
@@ -9780,7 +9778,6 @@ GEMFood.tr,GEM Food,,,Gem Group,TR,cooking,FALSE,,,,https://www.gemgroup.tv/
 GeminiComedy.in,Gemini Comedy,,Gemini,Sun TV Network,IN,comedy,FALSE,2010-01-10,2026-03-19,SunGeminiComedy.in,
 GeminiLife.in,Gemini Life,,Gemini,Sun TV Network,IN,lifestyle;classic,FALSE,,2026-03-19,SunGeminiLife.in,
 GeminiMovies.in,Gemini Movies,,Gemini,Sun TV Network,IN,movies,FALSE,2010-01-10,2026-03-19,SunGeminiMovies.in,
-GeminiMusic.in,Gemini Music,,Gemini,Sun TV Network,IN,music,FALSE,,2026-03-19,SunGeminiMusic.in,
 GeminiTV.in,Gemini TV,Gemini,Gemini,Sun TV Network,IN,entertainment,FALSE,1995-02-09,2026-03-19,SunGemini.in,
 GEMJunior.tr,GEM Junior,,,Gem Group,TR,kids,FALSE,,,,https://www.gemgroup.tv/
 GEMKids.tr,GEM Kids,,,Gem Group,TR,kids,FALSE,,,,https://www.gemgroup.tv/
@@ -24512,7 +24509,6 @@ RadioTelevizuneaDiasporei.ro,Radio Televizunea Diasporei,RTVD,,,RO,general,FALSE
 RadioTeleWisdom.us,Radio Tele Wisdom,,,,US,religious,FALSE,,,,https://radiotelewisdom.com/
 RadioTeleYaguana.ht,Radio Tele Yaguana,Radio Télé Yaguana,,,HT,general,FALSE,,,,http://www.radioyaguana.com/
 RadioTicinoChannel.it,Radio Ticino Channel,,,,IT,,FALSE,,,,
-RadiotjanstTV.se,Radiotjanst TV,Radiotjänst TV,,,SE,,FALSE,1956-01-01,1957-01-01,SverigesRadioTV.se,
 RadioToppers.nl,RadioToppers,,,,NL,entertainment,FALSE,,,,http://www.radio-toppers.net/
 RadioTouchTV.cl,Radio Touch TV,,,,CL,,FALSE,,,,https://www.radiotouchtv.cl/
 RadioTributoValentina.cl,Radio Tributo Valentina,,,,CL,,FALSE,,,,https://tributovalentina.cl/
@@ -28176,7 +28172,7 @@ SundomTV.fi,Sundom TV,,,,FI,,FALSE,,,,https://951.fi/
 Sundskanalen.se,Sundskanalen,,,,SE,general,FALSE,,,,https://sundskanalen.se/
 SunFMTV.zm,Sun FM TV,,,,ZM,general,FALSE,,,,https://www.sunfmzambia.net/
 SunGemini.in,Sun Gemini,Sun జెమినీ,Sun Gemini,Sun TV Network,IN,general,FALSE,2026-03-09,,,http://www.sunnetwork.in/tv-channel-details.aspx?Channelid=4&channelname=GEMINI%20TV&LanguageID=2&Type=2
-SunGeminiComedy.in,Sun Gemini Comedy,Sun జెమినీ Comedy,Sun Gemini,Sun TV Network,IN,comedy,FALSE,2026-03-19,,,http://www.sunnetwork.in/tv-channel-details.aspx?Channelid=42&channelname=GEMINI%20COMEDY&LanguageID=2&Type=2
+SunGeminiComedy.in,Sun Gemini Comedy,Sun జెమినీ Comedy;Gemini Comedy,Sun Gemini,Sun TV Network,IN,comedy,FALSE,,,,http://www.sunnetwork.in/tv-channel-details.aspx?Channelid=42&channelname=GEMINI%20COMEDY&LanguageID=2&Type=2
 SunGeminiLife.in,Sun Gemini Life,Sun జెమినీ Life;Gemini Life,Sun Gemini,Sun TV Network,IN,lifestyle,FALSE,2026-03-19,,,http://www.sunnetwork.in/
 SunGeminiMovies.in,Sun Gemini Movies,Sun జెమినీ Movies,Sun Gemini,Sun TV Network,IN,movies,FALSE,2026-03-19,,,http://www.sunnetwork.in/tv-channel-details.aspx?Channelid=26&channelname=GEMINI%20MOVIES&LanguageID=2&Type=2
 SunGeminiMusic.in,Sun Gemini Music,Sun జెమినీ Music,Sun Gemini,Sun TV Network,IN,music,FALSE,2026-03-19,,,http://www.sunnetwork.in/tv-channel-details.aspx?Channelid=34&channelname=GEMINI%20MUSIC&LanguageID=2&Type=2
@@ -30438,7 +30434,6 @@ TV1000.bg,TV1000,,,,BG,movies,FALSE,,,,https://tv1000.bg/
 TV1000.ro,TV1000,,Viasat,,RO,movies,FALSE,,,,https://tv1000.com.ro/
 TV1000.ru,TV1000,,,,RU,movies,FALSE,,,,http://www.myviasat.ru/channels/films/foreign_tv1000_movie
 TV1000.si,TV1000,,Viasat,,SI,movies,FALSE,,,,https://tv1000.si/
-TV1000CINEMA.se,TV1000 CINEMA,,,,SE,movies,FALSE,1995-01-01,2000-01-01,ViasatTV1000CINEMA1.se,
 TV100National.in,TV 100 National,,,,IN,,FALSE,,,,http://www.tv100.info/
 TV101.rs,TV 101,,,RTV 101 d.o.o.,RS,,FALSE,,,,
 TV10Rivera.uy,TV 10 Rivera,Tevediez Rivera,,Canal 10 TV Rivera Ltda,UY,general,FALSE,1968-05-18,,,https://tv10rivera.com.uy/
@@ -32776,7 +32771,6 @@ ViasatSport3.se,Viasat Sport 3,,,,SE,sports,FALSE,2004-01-01,2008-10-17,ViasatMo
 ViasatSportPremium.se,Viasat Sport Premium,,,,SE,sports,FALSE,2016-01-01,2020-01-01,VSportPremium.se,
 ViasatTrueCrime.pl,Viasat True Crime,,,,PL,,FALSE,,,,
 ViasatTV1000.se,Viasat TV1000,,,,SE,,FALSE,2004-01-01,2012-03-01,ViasatFilm.se,
-ViasatTV10001.se,Viasat TV1000 1,,,,SE,,FALSE,2000-01-01,2004-01-01,ViasatTV1000.se,
 ViasatTV10003.se,Viasat TV1000 3,,,,SE,,FALSE,2000-01-01,2004-01-01,ViasatTV1000Family.se,
 ViasatTV1000Action.se,Viasat TV1000 Action,,,,SE,,FALSE,2004-01-01,2012-01-01,ViasatFilmAction.se,
 ViasatTV1000CINEMA1.se,Viasat TV1000 CINEMA 1,,,,SE,movies,FALSE,2000-01-01,2004-01-01,ViasatTV1000Action.se,
@@ -32882,7 +32876,7 @@ VinhPhucTV.vn,Vinh Phuc TV,,,,VN,,FALSE,,,,http://vinhphuctv.vn/
 VinilosTV.pe,Vinilos TV,,,,PE,music,FALSE,2023-06-01,,,https://playmax.tv/
 VintageMusic.cr,Vintage Music,,,,CR,music,FALSE,,,,
 VinTV.es,VinTV,Vintage Televisión,,AMC Networks International Southern Europe,ES,series,FALSE,2025-07-01,,,https://amcchannels.es/vintv
-VinTV.pt,VinTV,Biggs,,NOS, SGPS S.A.;AMC Networks Inc.,PT,series,FALSE,2026-05-04,,,https://vintv.pt/
+VinTV.pt,VinTV,Biggs,,NOS SGPS S.A.;AMC Networks Inc.,PT,series,FALSE,2026-05-04,,,https://vintv.pt/
 VinxTV.es,Vinx TV,,,,ES,sports,FALSE,,,,https://www.vinxtv.es/
 VIOTV.sk,VIO TV,,,,SK,,FALSE,,,,http://viotv.sk/
 VIPNews.in,VIP News,,,Crystal Business System Ltd,IN,news,FALSE,,,,
@@ -39333,7 +39327,6 @@ ZeeRajasthan.in,Zee Rajasthan,,Zee Media,Zee Media Corporation Limited (ZMCL);Th
 ZeeSarthak.in,Zee Sarthak,,Z,Zee Entertainment Enterprises Limited,IN,entertainment,FALSE,2017-10-15,,,https://zeesarthak.zee5.com/
 ZeeSmile.us,Zee Smile,,,,US,,FALSE,,2016-01-15,,http://www.zeetelevision.com/
 ZeeSouthFlix.in,Zee South Flix,Z South Flix,ZEE5,Zee Entertainment Enterprises Limited,IN,movies,FALSE,2025-10-06,,,
-ZeeStudio.in,Zee Studio,,Z,Zee Entertainment Enterprises Limited,IN,movies,FALSE,2005-03-28,2018-06-03,Andflix.in,
 ZeeTalkies.in,Zee Talkies,,Z,Zee Entertainment Enterprises Limited,IN,movies,FALSE,,,,http://www.zeetalkies.tv/
 ZeeTamil.in,Zee Tamil,,Z,Zee Entertainment Enterprises Limited,IN,entertainment,FALSE,,,,http://zeetamil.zee5.com/
 ZeeTamilNews.in,Zee Tamil News,Zee தமிழ் News;ZEE News Tamil;ஜீ நியூஸ் தமிழ்,Zee Media,Zee Media Corporation Limited (ZMCL);The Essel Group,IN,news,FALSE,2022-01-25,,,https://zeenews.india.com/tamil/

--- a/data/channels.csv
+++ b/data/channels.csv
@@ -3015,7 +3015,7 @@ BigCityTV.us,Big City TV,,,Asylum Entertainment Group,US,entertainment,FALSE,,,,
 BIGCivicChannel.us,BIG Civic Channel,Brookline Interactive Group Civic Channel,,,US,general,FALSE,,,,http://brookline-interactive-group.cablecast.tv:8080/CablecastPublicSite/watch/2?channel=2
 BIGCommunityChannel.us,BIG Community Channel,Brookline Interactive Group Community Channel,,,US,general,FALSE,,,,https://brooklineinteractive.org/live/
 BigGangaTalkies.in,Big Ganga Talkies,,,,IN,,FALSE,,,,
-Biggs.pt,Biggs,,,NOS SGPS S.A.;AMC Networks Inc.,PT,kids,FALSE,2009-12-01,2026-05-04,VinTV,http://biggs.pt/
+Biggs.pt,Biggs,,,NOS SGPS S.A.;AMC Networks Inc.,PT,kids,FALSE,2009-12-01,2026-05-04,VinTV.pt,http://biggs.pt/
 BigiBetEPL.ng,BigiBet EPL,,,,NG,,FALSE,,,,https://www.bigibet.com/
 BigiBetLaLiga.ng,BigiBet LaLiga,,,,NG,sports,FALSE,,,,https://www.bigibet.com/
 BigiBetLucky6.ng,BigiBet Lucky 6,,,,NG,,FALSE,,,,https://www.bigibet.com/

--- a/data/feeds.csv
+++ b/data/feeds.csv
@@ -35755,6 +35755,7 @@ VinhPhucTV.vn,SD,SD,,TRUE,c/VN,Asia/Ho_Chi_Minh,vie,576i
 VinilosTV.pe,SD,SD,,TRUE,c/PE,America/Lima,spa,480i
 VintageMusic.cr,SD,SD,,TRUE,c/CR,America/Costa_Rica,spa,480i
 VinTV.es,SD,SD,,TRUE,c/ES,Europe/Madrid,spa,1080i
+VinTV.pt,HD,HD,,TRUE,c/PT,Europe/Lisbon,por,1080i
 VinxTV.es,SD,SD,,TRUE,s/ES-AS,Europe/Madrid,spa,576i
 VIOTV.sk,SD,SD,,TRUE,c/SK,Europe/Bratislava,slk,576i
 VIPNews.in,SD,SD,,TRUE,c/IN,Asia/Kolkata,hin,576i

--- a/data/logos.csv
+++ b/data/logos.csv
@@ -34489,6 +34489,7 @@ VinhPhucTV.vn,,TRUE,,118,58,PNG,https://i.imgur.com/jLgwX4X.png
 VinilosTV.pe,,TRUE,,225,224,PNG,https://i.imgur.com/wHgCMgd.png
 VintageMusic.cr,,TRUE,,512,296,JPEG,https://i.imgur.com/KImqYnN.jpeg
 VinTV.es,,TRUE,,960,498,PNG,https://upload.wikimedia.org/wikipedia/commons/thumb/c/cb/Logo_de_VinTV.png/960px-Logo_de_VinTV.png
+VinTV.pt,,TRUE,,1078,558,PNG,https://static.wikia.nocookie.net/logopedia/images/5/5b/VinTV_Portugal_2026.png
 VinxTV.es,,TRUE,,231,231,PNG,https://i.imgur.com/6EGV2eo.png
 VIOTV.sk,,TRUE,,200,96,PNG,https://i.imgur.com/7EL3VZ5.png
 VIPNews.in,,TRUE,,127,94,PNG,https://i.imgur.com/84kRaW1.png


### PR DESCRIPTION
Portugal will have a new channel, in May 4th 2026.
This PR adds logo and feed of VinTV.pt and adds closure date to Biggs.pt

As soon as this PR gets accepted, will make another in the `epg` repo for changing from Biggs to VinTV