### PR TITLE
Add logo for Althania.sy

### DIFF
--- a/data/logos.csv
+++ b/data/logos.csv
@@ -1437,6 +1437,7 @@ AlterChannel.gr,,TRUE,,500,143,PNG,https://upload.wikimedia.org/wikipedia/en/2/2
 AlternativaTV.cl,,TRUE,,512,171,PNG,https://i.imgur.com/KCrSbgv.png
 AlternativnaTV.ba,,TRUE,,182,200,PNG,https://i.imgur.com/p28feZ5.png
 AlternaTV.ar,,TRUE,color,100,100,PNG,https://tv.alterna.ar/alternatv.png
+Althania.sy,,TRUE,,145,64,SVG,https://www.althania.tv/themes/custom/althania/assets/images/stv-logo.svg
 Althingi.is,,TRUE,,417,311,PNG,https://i.imgur.com/tKNPdea.png
 AlticeStudio.fr,,TRUE,,160,176,PNG,https://i.imgur.com/3R7ZNvm.png
 AltInfoTV.ge,,TRUE,,100,100,PNG,https://i.imgur.com/9JyYz89.png


### PR DESCRIPTION
## Summary

- Add official SVG logo for **Althania** (Syria)
- Channel ID: `Althania.sy`
- Logo URL: `https://www.althania.tv/themes/custom/althania/assets/images/stv-logo.svg`
- Dimensions: 145x64 (SVG)

The channel website (`https://www.althania.tv/`) is already present in `channels.csv`. This PR only adds the missing logo entry.
