### PR TITLE
Replace Althania.sy logo with PNG

### DIFF
--- a/data/logos.csv
+++ b/data/logos.csv
@@ -1441,7 +1441,7 @@ AlterChannel.gr,,TRUE,,500,143,PNG,https://upload.wikimedia.org/wikipedia/en/2/2
 AlternativaTV.cl,,TRUE,,512,171,PNG,https://i.imgur.com/KCrSbgv.png
 AlternativnaTV.ba,,TRUE,,182,200,PNG,https://i.imgur.com/p28feZ5.png
 AlternaTV.ar,,TRUE,color,100,100,PNG,https://tv.alterna.ar/alternatv.png
-Althania.sy,,TRUE,,145,64,SVG,https://www.althania.tv/themes/custom/althania/assets/images/stv-logo.svg
+Althania.sy,,TRUE,,512,221,PNG,https://files.catbox.moe/60rmq2.png
 Althingi.is,,TRUE,,417,311,PNG,https://i.imgur.com/tKNPdea.png
 AlticeStudio.fr,,TRUE,,160,176,PNG,https://i.imgur.com/3R7ZNvm.png
 AltInfoTV.ge,,TRUE,,100,100,PNG,https://i.imgur.com/9JyYz89.png


### PR DESCRIPTION
## Summary
- Replace the Althania.sy SVG logo hosted on `althania.tv` with a PNG (512x221) on Catbox
- The old SVG often fails to display in IPTV clients and returns HTTP 403 on HEAD checks

