### PR TITLE
Add missing logos for Alkarma TV Discipleship and North America

### DIFF
--- a/data/logos.csv
+++ b/data/logos.csv
@@ -1265,8 +1265,10 @@ AlKaheraWalNas.eg,SD,TRUE,,242,122,PNG,https://i.ibb.co/SD0YYqYW/alkahera-welnas
 AlKaheraWalNas2.eg,,TRUE,,152,59,PNG,https://i.imgur.com/5GVcS8t.png
 AlkalemaTV.us,,TRUE,,512,512,JPEG,https://i.imgur.com/dtXLXiI.jpg
 AlkarmaTVAustralia.us,,TRUE,,500,512,PNG,https://i.imgur.com/90ykspa.png
+AlkarmaTVDiscipleship.us,,TRUE,,712,719,PNG,https://files.alkarmatv.com/2019/12/Logo.png
 AlkarmaTVFamily.us,,TRUE,,506,512,PNG,https://i.imgur.com/yUEuQA2.png
 AlkarmaTVMiddleEast.us,,TRUE,,501,512,PNG,https://i.imgur.com/6OmNw5A.png
+AlkarmaTVNorthAmerica.us,,TRUE,,712,719,PNG,https://files.alkarmatv.com/2019/12/Logo.png
 AlkarmaTVNorthAmericaCanada.us,,TRUE,,495,512,PNG,https://i.imgur.com/pnm60bq.png
 AlkarmaTVPraise.us,,TRUE,,495,512,PNG,https://i.imgur.com/bJLKkou.png
 AlkarmaTVTalmazaDiscipleship.us,,TRUE,,495,512,PNG,https://i.imgur.com/t2ZkRbr.png


### PR DESCRIPTION
Adds the missing logo records for two Alkarma TV channels that currently have no entry in `logos.csv`:

- `AlkarmaTVDiscipleship.us`
- `AlkarmaTVNorthAmerica.us`

Logo source: official website (https://alkarmatv.com/), direct HTTPS link `https://files.alkarmatv.com/2019/12/Logo.png` (PNG, 712x719, not geo-blocked, returns 200 `image/png`).

Notes:
- Only 2 rows added, no columns changed, CRLF line endings preserved.
- Rows inserted in the correct sort order (`channel` + `feed` + `url`).
- The other 7 Alkarma TV channels already have logos in the database.