### PR TITLE
ci: pin GitHub Actions to commit SHAs and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      actions-minor-patch:
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "ci"
+    ignore:
+      # Deliberately held at v1.8.2: 7c776462 switched deploy.yml to
+      # actions/create-github-app-token@v2, 5c2520c4 reverted it three days later.
+      - dependency-name: "tibdex/github-app-token"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,8 +9,8 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22.12.0'
           cache: 'npm'
@@ -29,7 +29,7 @@ jobs:
         if: steps.files.outputs.any_changed == 'true'
         run: npm install
       - name: check if files are crlf
-        uses: kforeverisback/check-crlf-extended@v2
+        uses: kforeverisback/check-crlf-extended@bb2dea99a7da756525ede285d33811e5552d3ceb # v2
         continue-on-error: false
         with:
           directory: ./data

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,21 +10,21 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: tibdex/github-app-token@v1.8.2
+      - uses: tibdex/github-app-token@0d49dd721133f900ebd5e0dff2810704e8defbc6 # v1.8.2
         if: ${{ !env.ACT }}
         id: create-app-token
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         if: ${{ env.ACT }}
         with:
           token: ${{ github.token }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         if: ${{ !env.ACT }}
         with:
           token: ${{ steps.create-app-token.outputs.token }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22.12.0'
           cache: 'npm'
@@ -32,7 +32,7 @@ jobs:
         run: npm install
       - name: export data to ./api
         run: npm run db:export
-      - uses: JamesIves/github-pages-deploy-action@4.1.1
+      - uses: JamesIves/github-pages-deploy-action@164583b9e44b4fc5910e78feb607ea7c98d3c7b9 # 4.1.1
         if: ${{ !env.ACT && github.ref == 'refs/heads/master' }}
         with:
           repository-name: iptv-org/api

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,21 +9,21 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         if: ${{ !env.ACT }}
         id: create-app-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         if: ${{ env.ACT }}
         with:
           token: ${{ github.token }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         if: ${{ !env.ACT }}
         with:
           token: ${{ steps.create-app-token.outputs.token }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22.12.0'
           cache: 'npm'
@@ -37,7 +37,7 @@ jobs:
       - name: validate changes
         run: npm run db:validate
       - name: check if files are crlf
-        uses: kforeverisback/check-crlf-extended@v2
+        uses: kforeverisback/check-crlf-extended@bb2dea99a7da756525ede285d33811e5552d3ceb # v2
         continue-on-error: false
         with:
           directory: ./data

--- a/.github/workflows/validate_issue.yml
+++ b/.github/workflows/validate_issue.yml
@@ -17,9 +17,9 @@ jobs:
       contains(join(github.event.issue.labels.*.name, ','), 'blocklist:')
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         if: ${{ !env.ACT }}
         id: create-app-token
         with:
@@ -27,7 +27,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: 'npm'

--- a/.github/workflows/validate_label.yml
+++ b/.github/workflows/validate_label.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         if: ${{ !env.ACT }}
         id: create-app-token
         with:


### PR DESCRIPTION
## What this does

Pins all 18 action references across the five workflows to full-length commit SHAs, and adds `.github/dependabot.yml` to keep those pins current.

**No action changes version.** Every SHA is the one its current tag already resolves to, verified against `git ls-remote`. This PR is a no-op at runtime; it only changes *how* the references are expressed.

## Why pin to SHAs

Tags are mutable. `@v4` is a pointer the action's maintainer — or anyone who compromises their repo — can move at any time, and your next workflow run silently executes different code.

This is not hypothetical. In March 2025, `tj-actions/changed-files` was compromised ([CVE-2025-30066](https://github.com/advisories/ghsa-mrrh-fwg8-r2c3)): the attacker retroactively repointed **every tag from `v1` through `v45.0.7`** at a malicious commit that dumped CI/CD secrets into workflow logs. Roughly **23,000 repositories** were affected, and CISA issued an alert. Repos pinned to a SHA were unaffected, because a SHA cannot be repointed. Repos on floating tags were compromised without changing a line of their own code.

GitHub's own [security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions) is unambiguous:

> Pinning an action to a full-length commit SHA is currently the only way to use an action as an immutable release.

> There is risk to this approach even if you trust the author, because a tag can be moved or deleted if a bad actor gains access to the repository storing the action.

### Why it matters specifically here

This is not a repo where a compromised action would be a minor inconvenience:

- `deploy.yml` and `update.yml` mint a **GitHub App token** from `secrets.APP_PRIVATE_KEY`.
- `update.yml` runs with `contents: write` and pushes to `master`.
- `deploy.yml` pushes to a **second repository**, `iptv-org/api`, using that app token.

Any action step running in those jobs sits next to a GitHub App private key with write access to two repos. Four of the six actions used here are third-party, and two of them (`kforeverisback/check-crlf-extended`, `tibdex/github-app-token`) are small, single-maintainer projects. That is precisely the profile the `tj-actions` attacker exploited.

## Why Dependabot is required, not optional

SHA pinning on its own is a **security regression over time**. It freezes you on a specific commit, so upstream security fixes never arrive. Pinning without automation trades a live risk for a slow one.

The current state of this repo shows exactly how that decay happens even *with* floating tags:

| Action | Uses | Current | Latest |
|---|---|---|---|
| `actions/checkout` | 7× | v4.4.0 | **v7.0.1** |
| `actions/setup-node` | 4× | v4.4.0 | **v7.0.0** |
| `actions/create-github-app-token` | 3× | v2.2.2 | **v3.2.0** |
| `kforeverisback/check-crlf-extended` | 2× | v2 | v2 ✅ |
| `tibdex/github-app-token` | 1× | v1.8.2 | v2.1.0 ⚠️ *archived upstream* |
| `JamesIves/github-pages-deploy-action` | 1× | 4.1.1 | **v4.9.0** |

Five of six are a major version behind — `actions/checkout` and `actions/setup-node` by **three majors**. 

Deliberately, this PR does **not** bump any of those versions. Each one is a reviewable decision, and Dependabot will raise them individually as PRs so maintainers can take them at their own pace.

## Cost: none

Dependabot does not consume Actions minutes. From GitHub's [Dependabot runner documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/about-dependabot-on-github-actions-runners):

> Running Dependabot on standard GitHub-hosted or self-hosted runners **does not** count towards your included GitHub Actions minutes.

The only exception is larger runners, which this config does not use. This repository is public, where standard runners are free regardless. There is no billing impact.

## Config

Weekly on Monday. Minor and patch updates are grouped into a single PR; **major bumps are never grouped** and always arrive individually, so the risky upgrades stay reviewable one at a time.

`tibdex/github-app-token` is ignored. That pin is intentional: 7c776462 switched `deploy.yml` to `actions/create-github-app-token@v2`, and 5c2520c4 reverted it three days later. The ignore stops Dependabot from re-litigating a decision that was already made, and the reason is recorded inline so the next person doesn't undo it.
